### PR TITLE
Fixes made during hackathon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ src_path=${HOME}/.local/src/treeppl/
 tppl_src=src/.
 
 tppl_tmp_file := $(shell mktemp)
-build/${tppl_name}: $(shell find . -name "*.mc" -o -name "*.syn")
+build/${tppl_name}: $(shell find src -name "*.mc" -o -name "*.syn")
 	mi syn src/treeppl.syn src/treeppl-ast.mc
 	time mi compile src/${tppl_name}.mc --output ${tppl_tmp_file}
 	mkdir -p build
@@ -38,4 +38,3 @@ test: src/treeppl-to-coreppl/compile.mc
 clean:
 	rm src/treeppl-ast.mc
 	rm build/*
-	

--- a/src/src-location.mc
+++ b/src/src-location.mc
@@ -2,7 +2,7 @@
 
 include "sys.mc"
 
-let tpplSrcCwd = sysGetCwd ()
+let tpplSrcCwd = concat (sysGetCwd ()) "/src"
 
 let tpplSrcLocUnix =
   match sysGetEnv "HOME" with Some path then

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -207,7 +207,7 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
 
   sem compile (input: Expr) =
   | FileTppl x ->
-    let externals = parseMCoreFile (concat tpplSrcLoc "/src/externals/ext.mc") in
+    let externals = parseMCoreFile (concat tpplSrcLoc "/externals/ext.mc") in
     let exts = setOfSeq cmpString ["externalLog", "externalExp"] in
     let externals = filterExternalMap exts externals in  -- strip everything but needed stuff from externals
     let externals = symbolize externals in

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -586,7 +586,7 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
   -- inference/type-checking. This seems like a problem that should
   -- appear in many languages, i.e., we want a good way of supporting
   -- it in MExpr. I guess a superset that includes some form of ad-hoc
-  -- overleading?
+  -- overloading?
   | AddExprTppl x ->
     TmApp {
       info = x.info,
@@ -672,6 +672,23 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
       ty = tyunknown_
     }
 
+  | LessExprTppl x ->
+    TmApp {
+      info = x.info,
+      lhs = TmApp {
+        info = x.info,
+        lhs = TmConst {
+          ty = tyunknown_,
+          info = x.info,
+          val = CLtf ()
+        },
+        rhs = compileExprTppl x.left,
+        ty = tyunknown_
+      },
+      rhs = compileExprTppl x.right,
+      ty = tyunknown_
+    }
+
   | GreaterExprTppl x ->
     TmApp {
       info = x.info,
@@ -681,6 +698,24 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
           ty = tyunknown_,
           info = x.info,
           val = CGtf ()
+        },
+        rhs = compileExprTppl x.left,
+        ty = tyunknown_
+      },
+      rhs = compileExprTppl x.right,
+      ty = tyunknown_
+    }
+
+
+  | GreaterEqExprTppl x ->
+    TmApp {
+      info = x.info,
+      lhs = TmApp {
+        info = x.info,
+        lhs = TmConst {
+          ty = tyunknown_,
+          info = x.info,
+          val = CGeqf ()
         },
         rhs = compileExprTppl x.left,
         ty = tyunknown_
@@ -703,6 +738,53 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
         ty = tyunknown_
       },
       rhs = compileExprTppl x.right,
+      ty = tyunknown_
+    }
+
+  | UnequalExprTppl x ->
+    TmApp {
+      info = x.info,
+      lhs = TmApp {
+        info = x.info,
+        lhs = TmConst {
+          ty = tyunknown_,
+          info = x.info,
+          val = CNeqf ()
+        },
+        rhs = compileExprTppl x.left,
+        ty = tyunknown_
+      },
+      rhs = compileExprTppl x.right,
+      ty = tyunknown_
+    }
+
+  | AndExprTppl x ->
+    TmMatch {
+      info = x.info,
+      target = compileExprTppl x.left,
+      pat = PatBool { val = true, info = get_ExprTppl_info x.left, ty = tyunknown_ },
+      thn = compileExprTppl x.right,
+      els = TmConst { info = x.info, ty = tyunknown_, val = CBool { val = false } },
+      ty = tyunknown_
+    }
+
+  | OrExprTppl x ->
+    TmMatch {
+      info = x.info,
+      target = compileExprTppl x.left,
+      pat = PatBool { val = true, info = get_ExprTppl_info x.left, ty = tyunknown_ },
+      thn = TmConst { info = x.info, ty = tyunknown_, val = CBool { val = true } },
+      els = compileExprTppl x.right,
+      ty = tyunknown_
+    }
+
+  | NotExprTppl x ->
+    TmMatch {
+      info = x.info,
+      target = compileExprTppl x.right,
+      pat = PatBool { val = true, info = get_ExprTppl_info x.right, ty = tyunknown_ },
+      thn = TmConst { info = x.info, ty = tyunknown_, val = CBool { val = false } },
+      els = TmConst { info = x.info, ty = tyunknown_, val = CBool { val = true } },
       ty = tyunknown_
     }
 

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -345,6 +345,10 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
       info = x.info
     }
 
+  | AtomicIntTypeTppl x -> TyInt {
+      info = x.info
+    }
+
   sem compileStmtTppl: TpplCompileContext -> StmtTppl -> (Expr -> Expr)
 
   sem compileStmtTppl (context: TpplCompileContext) =
@@ -510,9 +514,11 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
 
   | PrintStmtTppl x ->
     lam cont.
-      let print = print_ (snoc_ (float2string_ (compileExprTppl x.real)) (char_ '\n')) in
-      let flush = flushStdout_ unit_ in
-      isemi_ (isemi_ print flush) cont
+      foldr isemi_ cont
+        [ dprint_ (compileExprTppl x.real)
+        -- , print_ (str_ "\n") in
+        , flushStdout_ unit_
+        ]
 
   sem compileExprTppl: ExprTppl -> Expr
 

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -722,6 +722,9 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
       ty = tyunknown_
     }
 
+  | ConvIntToRealExprTppl x ->
+    withInfo x.info (int2float_ (compileExprTppl x.val))
+
   | LessEqExprTppl x ->
     TmApp {
       info = x.info,

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -79,7 +79,7 @@ Real[]
 Int[10]
 -/
 prod TypeTppl: TypeTppl = name:UName
-prod Sequence: TypeTppl = ty:TypeTppl "[" size:Integer? "]"
+prod SequenceTypeTppl: TypeTppl = ty:TypeTppl "[" size:Integer? "]"
 
 prod AtomicReal: TypeTppl = "Real"
 prod AtomicBool: TypeTppl = "Bool"
@@ -121,6 +121,7 @@ prod Real: ExprTppl = val:Real
 prod Variable: ExprTppl = ident:LName
 prod True: ExprTppl = "true"
 prod False: ExprTppl = "false"
+prod Sequence: ExprTppl = "[" (values:ExprTppl ("," values:ExprTppl)*)? "]"
 
 
 -- infix left Addition: Expr = "+"
@@ -146,6 +147,8 @@ prod left Unequal: ExprTppl = left:ExprTppl "!=" right:ExprTppl
 infix left And: ExprTppl = "&&"
 infix left Or: ExprTppl = "||"
 prefix Not: ExprTppl = "!"
+-- List operations
+postfix Subscript: ExprTppl = "[" idx:ExprTppl (":" lastIdx:ExprTppl)? "]"
 
 
 -- Function call as expression
@@ -154,10 +157,12 @@ prod FunCall: ExprTppl = f:ExprTppl "(" (args:ExprTppl ("," args:ExprTppl)*)? ")
 prod Projection: ExprTppl = target:ExprTppl "." field:LIdent
 
 precedence {
-  Projection FunCall;
+  Projection FunCall Subscript;
+  Not;
   Mul Div;
   Add Sub;
   ~Less Greater LessEq GreaterEq Equal Unequal;
+  ~And Or;
 }
 
 -- Built-in distro keywords

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -189,7 +189,7 @@ prod Resample: StmtTppl = "resample" ";"
 prod If: StmtTppl = "if" condition:ExprTppl "{" ifTrueStmts:StmtTppl* "}" ("else" "{" ifFalseStmts:StmtTppl* "}")?
 prod Weight: StmtTppl = "weight" value:ExprTppl ";"
 prod LogWeight: StmtTppl = "logWeight" value:ExprTppl ";"
-prod ForLoop: StmtTppl = "for" iterator:LName "in" range:ExprTppl "{" forStmts:StmtTppl+ "}"
+prod ForLoop: StmtTppl = "for" iterator:LName "in" range:ExprTppl "{" forStmts:StmtTppl* "}"
 prod Return: StmtTppl = "return" return:ExprTppl? ";"
 
 prod Print: StmtTppl = "print" "(" real:ExprTppl ")" ";"

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -142,6 +142,11 @@ prod left LessEq: ExprTppl = left:ExprTppl "<=" right:ExprTppl
 prod left GreaterEq: ExprTppl = left:ExprTppl ">=" right:ExprTppl
 prod left Equal: ExprTppl = left:ExprTppl "==" right:ExprTppl
 prod left Unequal: ExprTppl = left:ExprTppl "!=" right:ExprTppl
+-- Boolean operators
+infix left And: ExprTppl = "&&"
+infix left Or: ExprTppl = "||"
+prefix Not: ExprTppl = "!"
+
 
 -- Function call as expression
 prod FunCall: ExprTppl = f:ExprTppl "(" (args:ExprTppl ("," args:ExprTppl)*)? ")"

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -94,7 +94,7 @@ prod Fun: DeclTppl =
   model:"model"? "function" name:LName
   "(" (args:{name:LName ":" ty:TypeTppl} args:{"," name:LName ":" ty:TypeTppl}*)? ")"
   (":" returnTy:TypeTppl)?
-  "{" body:StmtTppl+ "}"
+  "{" body:StmtTppl* "}"
 
 /-
 A (type) constructor is similar to a function but needs to have at least one

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -150,6 +150,8 @@ infix left Or: ExprTppl = "||"
 prefix Not: ExprTppl = "!"
 -- List operations
 postfix Subscript: ExprTppl = "[" idx:ExprTppl (":" lastIdx:ExprTppl)? "]"
+-- Conversions, not sure this is actually what we want in the end
+prod ConvIntToReal: ExprTppl = "Real" "(" val:ExprTppl ")"
 
 
 -- Function call as expression

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -83,6 +83,7 @@ prod SequenceTypeTppl: TypeTppl = ty:TypeTppl "[" size:Integer? "]"
 
 prod AtomicReal: TypeTppl = "Real"
 prod AtomicBool: TypeTppl = "Bool"
+prod AtomicInt: TypeTppl = "Int"
 
 
 /-


### PR DESCRIPTION
This PR includes a number of relatively simple features that were missing.
- Actual support for operators already in the `.syn` file, plus boolean operators.
- Fix how `make install` installs src files, which are needed for compilation of models
- Basic support for sequences: literals (`[1, 2, 3]`), ranges (`a to b`), subscript (`xs[idx]` 1-indexed), and slicing (`xs[start:end]` 1-indexed, inclusive both indices)
- For loops that iterate through sequences (and support `return` inside).
- Added `Int` builtin type and a conversion from int to real via `Real(expr)`. For the other direction we need to pick semantics (round, floor, ceil, truncate), and/or provide all of the conversions. If we choose the latter I'd suggest making them functions in the stdlib, in which case we need to implement a treeppl stdlib and a mechanism for including it by default (we should almost certainly do this anyway).

Manual testing suggests that all of these work, and some of the previously written models might compile now, but I have not made the effort to test the models or otherwise ensure automatic testing of these new features.