### PR TITLE
Regression fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+out
+out.mc
 .DS_Store
 tool
 build/

--- a/src/tpplc.mc
+++ b/src/tpplc.mc
@@ -44,7 +44,7 @@ if eqString backend "rootppl" then
     let corePplAst: Expr = compile input file in
     --  TODO(vsenderov,2022-05-10): Maybe parse from the command line
     let outfile = "out.cu" in
-    let options = {default with method = "rootppl-smc"} in
+    let options = {default with method = "smc-bpf", target = "rootppl"} in
     printLn "NEVER!";
     let prog: Expr = typeCheck corePplAst in
     --let prog = corePplAst in
@@ -71,7 +71,7 @@ else -- defaulting to MExpr
 
     let corePplAst: Expr = compile input file in
     --dprint corePplAst;
-    let options = { default with method = "mexpr-smc-bpf", particles = 1 } in
+    let options = { default with method = "smc-bpf", particles = 1, target = "mexpr" } in
     -- printLn (mexprPPLToString corePplAst);
     --let prog = corePplAst in
     let prog: Expr = typeCheck corePplAst in

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -215,7 +215,6 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
     let externals = parseMCoreFile (concat tpplSrcLoc "/externals/ext.mc") in
     let exts = setOfSeq cmpString ["externalLog", "externalExp"] in
     let externals = filterExternalMap exts externals in  -- strip everything but needed stuff from externals
-    -- printLn (mexprToString externals);
     let externals = symbolize externals in
     let externalMap = constructExternalMap externals in
     let compileContext: TpplCompileContext = {


### PR DESCRIPTION
- Fixes an issue with `filterExternalMap`, that previously did not remove all top-level expressions that were not external definitions.
- Update `method` and `target` to use updated CorePPL arguments.

We should merge this PR at the same time as https://github.com/miking-lang/miking-dppl/pull/131.