### PR TITLE
Standardizing the TreePPL command line to follow CorePPL

### DIFF
--- a/src/tpplc.mc
+++ b/src/tpplc.mc
@@ -77,6 +77,8 @@ match result with ParseOK r in
     use TreePPLThings in
     match parseTreePPLExn filename content with  file in
     let corePplAst: Expr = compile input file in
+    --let prog: Expr = typeCheck corePplAst in
+    --let prog: Expr = lowerProj prog in
     -- Now we have the coreppl AST. Can we follow the cppl logic again?
     let ast = corePplAst in
     let noInfer = not (hasInfer ast) in
@@ -94,23 +96,6 @@ match result with ParseOK r in
       let ast = mexprCpplCompile options noInfer ast in
     --dprint corePplAst;
     --printLn (mexprPPLToString corePplAst);
-    --? let prog: Expr = typeCheck corePplAst in
-    --? let prog: Expr = lowerProj prog in
-    --? match programModelTransform options prog with (runtimes, prog) in
-    -- (viktors, 2023-05-19) Copied this from cppl command line
-    -- ?let ast = prog in
-    --? if eqString options.target "rootppl" then
-    --?  if mapIsEmpty runtimes then
-    --?    let ast =
-    --?      if options.transform then transform ast
-    --?      else ast
-    --?    in
-    --?    let ast = rootPPLCompile options ast in
-    --?    buildRootPPL options ast
-    --?  else error "Use of infer is not supported by RootPPL backend"
-    --?else
-    --?  let runtimes = combineRuntimes options runtimes in
-    --?  let ast = mexprCompile options runtimes prog in
 
     --(vsenderov, 2023-06-16 We use our own output for now for now)
       writeFile outName (use MExpr in concat "mexpr\n" (mexprToString ast));

--- a/src/tpplc.mc
+++ b/src/tpplc.mc
@@ -77,10 +77,10 @@ match result with ParseOK r in
     use TreePPLThings in
     match parseTreePPLExn filename content with  file in
     let corePplAst: Expr = compile input file in
-    --let prog: Expr = typeCheck corePplAst in
-    --let prog: Expr = lowerProj prog in
+    let prog: Expr = typeCheck corePplAst in
+    let prog: Expr = lowerProj prog in
     -- Now we have the coreppl AST. Can we follow the cppl logic again?
-    let ast = corePplAst in
+    let ast = prog in
     let noInfer = not (hasInfer ast) in
     if eqString options.target "rootppl" then
       if noInfer then

--- a/src/tpplc.mc
+++ b/src/tpplc.mc
@@ -2,6 +2,8 @@
 TreePPL Compiler command line
 -/
 
+-- (vsenderov, 2923-06-16 I don't remeber what are all the includes for any more;
+-- perhaps we should test and see if we need all of them)
 include "sys.mc"
 
 include "mexpr/ast.mc"
@@ -10,84 +12,117 @@ include "mexpr/type-check.mc"
 
 include "treeppl-to-coreppl/compile.mc"
 
-lang CorePPLUsage =
-  CPPLBackcompat + LoadRuntime +
-  ImportanceSamplingMethod + BPFMethod + APFMethod +
-  LightweightMCMCMethod  + NaiveMCMCMethod + TraceMCMCMethod +
-	PIMHMethod + ProjMatchPprint
+include "coreppl::dppl-arg.mc" -- inherit cmd-line opts from cppl
+include "coreppl::coreppl-to-rootppl/compile.mc"
+include "coreppl::build.mc"
+
+--lang CorePPLUsage =
+--  CPPLBackcompat + LoadRuntime +
+--  ImportanceSamplingMethod + BPFMethod + APFMethod +
+--  LightweightMCMCMethod  + NaiveMCMCMethod + TraceMCMCMethod +
+--	PIMHMethod + ProjMatchPprint
+--end
+
+-- (vsenderov, 2023-06-16 The CPPL language as defined in the cppl command line)
+lang CPPLLang =
+  MExprAst + MExprCompile + TransformDist + MExprEliminateDuplicateCode +
+  MExprSubstitute + MExprPPL
+
+  -- Check if a CorePPL program uses infer
+  sem hasInfer =
+  | expr -> hasInferH false expr
+  
+  sem hasInferH acc =
+  | TmInfer _ -> true
+  | expr -> sfold_Expr_Expr hasInferH acc expr
+
 end
 
 lang TreePPLThings = TreePPLAst + TreePPLCompile
   + LowerProjMatch + ProjMatchTypeCheck + ProjMatchPprint
 end
 
+-- Command line menu for TreePPL
+let tpplMenu = lam. join [
+  "Usage: tpplc program.tppl in.mc out.mc [<options>]\n\n",
+  "Options:\n",
+  argHelpOptions config,
+  "\n"
+] 
+
 mexpr
 
-use CorePPLUsage in
+-- (vsenderov, 2023-06-16 Changed this to CPPLLang as it is in the cppl command line)
+-- use CorePPLUsage in
+use CPPLLang in
 
-let backend = "mexpr" in
-
-if eqString backend "rootppl" then
-  match argv with ![_, _, _] then -- TODO use argparse
-    printLn "-- Error: arguments";
-    printLn "-- Correct: tpplc program.tppl data.mc";
+-- Use the arg.mc library to parse arguments
+let result = argParse default config in
+match result with ParseOK r in
+  let options: Options = r.options in
+  -- Print menu if not exactly three file arguments
+  if neqi (length r.strings) 3 then
+    print (tpplMenu ());
     exit 0
-  else match argv with [_, filename, data] in
-  use BootParser in
-  let input = parseMCoreFile {defaultBootParserParseMCoreFileArg with   eliminateDeadCode = false}
-    data in
-  let content = readFile filename in
-  use TreePPLAst in
-  match parseTreePPLExn filename content with  file in
-
-  use TreePPLCompile in
+  else
+    match r.strings with [filename, data, outName] in
+    -- (vsenderov, 2023-06-16) until here the logic follows the cppl command line
+    -- The data is an mcore file; that can be parsed with the bootparser
+    use BootParser in
+    let input = parseMCoreFile {
+        defaultBootParserParseMCoreFileArg with eliminateDeadCode = false, allowFree = true
+      } data in
+    -- However, now filename is a tppl program so it has to be parsed with TreePPLThings
+    let content = readFile filename in
+    use TreePPLThings in
+    match parseTreePPLExn filename content with  file in
     let corePplAst: Expr = compile input file in
-    --  TODO(vsenderov,2022-05-10): Maybe parse from the command line
-    let outfile = "out.cu" in
-    let options = {default with method = "smc-bpf", target = "rootppl"} in
-    printLn "NEVER!";
-    let prog: Expr = typeCheck corePplAst in
-    --let prog = corePplAst in
-    writeFile outfile (printCompiledRPProg (rootPPLCompile options prog));
-    -- mexprCompile backend
-    print (join ["RootPPL output written.\n",
-     "To get an executable, compile with \n\n  rootppl --stack-size 10000 ",   outfile, "\n\n"]);
-    use MExprPPL in
-    print (concat (mexprPPLToString corePplAst) "\n\n")
+    -- Now we have the coreppl AST. Can we follow the cppl logic again?
+    let ast = corePplAst in
+    let noInfer = not (hasInfer ast) in
+    if eqString options.target "rootppl" then
+      if noInfer then
+        let ast =
+          if options.transform then transform ast
+          else ast
+        in
+        let ast = rootPPLCompile options ast in
+        buildRootPPL options ast
+      else error "Use of infer is not supported by RootPPL backend"
 
-else -- defaulting to MExpr
-  use TreePPLThings in
-  match argv with ![_, _, _, _] then -- TODO use argparse
-    printLn "-- Error: arguments";
-    printLn "-- Correct: tpplc program.tppl data.mc output.mc";
-    exit 0
-  else match argv with [_, filename, data, outName] in
-  let input = use BootParser in
-    parseMCoreFile
-      {defaultBootParserParseMCoreFileArg with eliminateDeadCode = false, allowFree = true}
-      data in
-  let content = readFile filename in
-  match parseTreePPLExn filename content with  file in
-
-    let corePplAst: Expr = compile input file in
+    else
+      let ast = mexprCpplCompile options noInfer ast in
     --dprint corePplAst;
-    let options = { default with method = "smc-bpf", particles = 1, target = "mexpr" } in
-    -- printLn (mexprPPLToString corePplAst);
-    --let prog = corePplAst in
-    let prog: Expr = typeCheck corePplAst in
-    let prog: Expr = lowerProj prog in
-    match programModelTransform options prog with (runtimes, prog) in
-    let runtimes = combineRuntimes options runtimes in
-    let ast = mexprCompile options runtimes prog in
-    writeFile outName (use MExpr in concat "mexpr\n" (mexprToString ast));
+    --printLn (mexprPPLToString corePplAst);
+    --? let prog: Expr = typeCheck corePplAst in
+    --? let prog: Expr = lowerProj prog in
+    --? match programModelTransform options prog with (runtimes, prog) in
+    -- (viktors, 2023-05-19) Copied this from cppl command line
+    -- ?let ast = prog in
+    --? if eqString options.target "rootppl" then
+    --?  if mapIsEmpty runtimes then
+    --?    let ast =
+    --?      if options.transform then transform ast
+    --?      else ast
+    --?    in
+    --?    let ast = rootPPLCompile options ast in
+    --?    buildRootPPL options ast
+    --?  else error "Use of infer is not supported by RootPPL backend"
+    --?else
+    --?  let runtimes = combineRuntimes options runtimes in
+    --?  let ast = mexprCompile options runtimes prog in
 
-    -- Output the compiled OCaml code (unless --skip-final is specified)
-    -- let xx = if options.skipFinal then
-    --   -- print (join ["Miking output written.\n", "To get an executable, compile with \n\n  mi compile ",outName, "\n\n"]);
-    --   ()
-    -- else sysRunCommand ["mi", "compile", outName] "" ".";
-    --   -- print (join ["Executable compiled.\n", "To run \n\n  ./out \n\n"]);
-    --   ()
-    -- in
-    -- print (concat (mexprPPLToString corePplAst) "\n\n");
-    ()
+    --(vsenderov, 2023-06-16 We use our own output for now for now)
+      writeFile outName (use MExpr in concat "mexpr\n" (mexprToString ast));
+      
+
+      -- Output the compiled OCaml code (unless --skip-final is specified)
+      -- let xx = if options.skipFinal then
+      --   -- print (join ["Miking output written.\n", "To get an executable, compile with \n\n  mi compile ",outName, "\n\n"]);
+      --   ()
+      -- else sysRunCommand ["mi", "compile", outName] "" ".";
+      --   -- print (join ["Executable compiled.\n", "To run \n\n  ./out \n\n"]);
+      --   ()
+      -- in
+      -- print (concat (mexprPPLToString corePplAst) "\n\n");
+      ()

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -211,7 +211,7 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
   sem compile: Expr -> FileTppl -> Expr
 
   sem compile (input: Expr) =
-  | FileTppl x ->
+  | DeclSequenceFileTppl x ->
     let externals = parseMCoreFile (concat tpplSrcLoc "/externals/ext.mc") in
     let exts = setOfSeq cmpString ["externalLog", "externalExp"] in
     let externals = filterExternalMap exts externals in  -- strip everything but needed stuff from externals
@@ -296,7 +296,7 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
   sem compileTpplTypeDecl: TpplCompileContext -> DeclTppl -> (Option {v:Name, i:Info}, [({v:Name, i:Info}, Type)])
   sem compileTpplTypeDecl context =
   | TypeDeclTppl x ->
-    let f = lam c. match c with Con c in
+    let f = lam c. match c with TypeCon c in
       let mkField = lam x. (x.name.v, compileTypeTppl x.ty) in
       let tycon = tyWithInfo x.name.i (ntycon_ x.name.v) in
       let record = tyWithInfo x.info (tyrecord_ (map mkField c.fields)) in
@@ -337,7 +337,7 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + RecLetsAst + Externals + MExprSym 
   sem compileTypeTppl: TypeTppl -> Type
 
   sem compileTypeTppl =
-  | TypeTppl x -> TyCon {
+  | TypeUsageTypeTppl x -> TyCon {
       ident = x.name.v,
       info = x.name.i
     }

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -7,6 +7,7 @@ token String {
   repr = StringRepr {},
   constructor = StringTok,
   fragment = StringTokenParser,
+  ty = String,
 }
 token LIdent {
   repr = LIdentRepr {},
@@ -68,7 +69,7 @@ start FileTppl
 /-
 A TreePPL file consists of one more declarations.
 -/
-prod FileTppl: FileTppl = decl:DeclTppl+
+prod DeclSequence: FileTppl = decl:DeclTppl+
 
 /-
 Type usage
@@ -78,7 +79,7 @@ Real
 Real[]
 Int[10]
 -/
-prod TypeTppl: TypeTppl = name:UName
+prod TypeUsage: TypeTppl = name:UName
 prod SequenceTypeTppl: TypeTppl = ty:TypeTppl "[" size:Integer? "]"
 
 prod AtomicReal: TypeTppl = "Real"
@@ -101,7 +102,7 @@ prod Fun: DeclTppl =
 A (type) constructor is similar to a function but needs to have at least one
 argument, and does not have the optional postfix :SomeType
 -/
-prod Con: Con =
+prod TypeCon: Con =
  name:UName "{"( fields:{name:LIdent ":" ty:TypeTppl} ("," fields:{name:LIdent ":" ty:TypeTppl})*)? "}"
 
 /- Here is how you declare a type -/
@@ -117,7 +118,7 @@ prod Type: DeclTppl =
 Expressions
 -/
 prod Integer: ExprTppl = val:Integer
-prod String: ExprTppl = val:String
+prod TpplString: ExprTppl = val:String
 prod Real: ExprTppl = val:Real
 prod Variable: ExprTppl = ident:LName
 prod True: ExprTppl = "true"


### PR DESCRIPTION
The TreePPL command line now accepts the same options as the CorePPL command line and it uses the same logic.