### PR TITLE
Python interface to TreePPL

### DIFF
--- a/python/examples/coin.py
+++ b/python/examples/coin.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+import sys
+sys.path.append("..")
+
+import treeppl
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+source = """\
+model function coin(outcomes: Bool[]): Real {
+  assume p ~ Beta(2.0, 2.0);
+  for i in 1 to (length(outcomes)) {
+    observe outcomes[i] ~ Bernoulli(p);
+  }
+  return(p);
+}
+"""
+
+with treeppl.Model(source=source, samples=10_000) as coin:
+    res = coin(outcomes=[True, True, True, False, True, False, False, True, True, False, False, False, True, False, True, False, False, True, False, False])
+    sns.histplot(x=res.samples, weights=res.nweights, bins=100, stat="density", kde=True)
+    plt.show()

--- a/python/examples/crbd.py
+++ b/python/examples/crbd.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+import sys
+sys.path.append("..")
+
+import treeppl
+import json
+from Bio import Phylo
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+class Tree:
+    @treeppl.constructor('Node')
+    class Node(treeppl.Object):
+        def __repr__(self):
+            return f"Node(left={self.left!r}, right={self.right!r}, age={self.age})"
+
+    @treeppl.constructor('Leaf')
+    class Leaf(treeppl.Object):
+        def __repr__(self):
+            return f"Leaf(age={self.age})"
+
+    @staticmethod
+    def load_nexus(filename):
+        tree = Phylo.read(filename, "nexus")
+        if not tree.is_bifurcating():
+            return
+        tree_depths = tree.depths()
+        max_age = max(tree_depths.values())
+        def convert(clade):
+            if clade.is_terminal():
+                return Tree.Leaf(
+                    age=max_age - tree_depths[clade]
+                )
+            else:
+                return Tree.Node(
+                    left=convert(clade.clades[0]),
+                    right=convert(clade.clades[1]),
+                    age=max_age - tree_depths[clade]
+                )
+        return convert(tree.root)
+
+    @staticmethod
+    def load_phyjson(filename):
+        def age(node):
+            children = node.get('children')
+            if children:
+                return max(0., node.get('branch_length', 0)) + max(age(children[0]), age(children[1]))
+            return node['branch_length']
+        def convert(node, age):
+            age -= max(0, node.get('branch_length'))
+            children = node.get('children')
+            if children:
+                node = Tree.Node(
+                    left=convert(children[0], age),
+                    right=convert(children[1], age),
+                    age=age
+                )
+                return node
+            else:
+                return Tree.Leaf(age=age)
+        phyjson = json.load(open(filename, 'r'))
+        return convert(
+            phyjson['trees'][0]['root'],
+            age(phyjson['trees'][0]['root'])
+        )
+
+
+tree = Tree.load_phyjson("trees/Alcedinidae.phyjson")
+rho = 0.5684210526315789
+
+sweep_samples = 10_000
+sweep_subsamples = 100
+weights = []
+samples = []
+with treeppl.Model(filename="crbd.tppl", samples=sweep_samples) as crbd:
+    while True:
+        res = crbd(tree=tree, rho=rho)
+        samples.extend(res.subsample(sweep_subsamples))
+        weights.extend([res.norm_const]*sweep_subsamples)
+        plt.clf()
+        sns.kdeplot(x=samples, weights=np.exp(np.array(weights)-max(weights)))
+        plt.pause(0.05)

--- a/python/examples/crbd.tppl
+++ b/python/examples/crbd.tppl
@@ -1,0 +1,65 @@
+type Tree =
+  | Node {left: Tree, right: Tree, age: Real}
+  | Leaf {age: Real}
+
+function countLeaves(tree: Tree): Real {
+  if tree is Node {
+    return countLeaves(tree.left) + countLeaves(tree.right);
+  }
+  return 1.0;
+}
+
+function logFactorial(n: Real): Real {
+  if n <= 1.0 {
+    return 0.0;
+  }
+  return log(n) + logFactorial(n - 1.0);
+}
+
+function simulateSubtree(time: Real, lambda: Real, mu: Real, rho: Real) {
+  assume waitingTime ~ Exponential(lambda + mu);
+  if waitingTime > time {
+    assume detected ~ Bernoulli(rho);
+    if detected {
+      weight 0.0;
+      resample;
+    }
+  } else {
+    assume isSpeciation ~ Bernoulli(lambda / (lambda + mu));
+    if isSpeciation {
+      simulateSubtree(time - waitingTime, lambda, mu, rho);
+      simulateSubtree(time - waitingTime, lambda, mu, rho);
+    }
+  }
+}
+
+function walk(node: Tree, time:Real, lambda: Real, mu: Real, rho: Real) {
+  assume waitingTime ~ Exponential(lambda);
+  if time - waitingTime > node.age {
+    simulateSubtree(time - waitingTime, lambda, mu, rho);
+    weight 2.0;
+    observe 0 ~ Poisson(mu * waitingTime);
+    walk(node, time - waitingTime, lambda, mu, rho);
+  } else {
+    observe 0 ~ Poisson(mu * (time - node.age));
+    if node is Node {
+      observe 0.0 ~ Exponential(lambda);
+      resample;
+      walk(node.left, node.age, lambda, mu, rho);
+      walk(node.right, node.age, lambda, mu, rho);
+    } else {
+      observe true ~ Bernoulli(rho);
+      resample;
+    }
+  }
+}
+
+model function crbd(tree: Tree, rho: Real): Real {
+  assume lambda ~ Gamma(1.0, 1.0);
+  assume mu ~ Gamma(1.0, 0.5);
+  let leaves = countLeaves(tree);
+  logWeight log(2.0) * (leaves - 1.0) - logFactorial(leaves);
+  walk(tree.left, tree.age, lambda, mu, rho);
+  walk(tree.right, tree.age, lambda, mu, rho);
+  return lambda;
+}

--- a/python/examples/trees/Alcedinidae.phyjson
+++ b/python/examples/trees/Alcedinidae.phyjson
@@ -1,0 +1,762 @@
+{
+    "format": "phyjson",
+    "taxa": [
+        {
+            "id": 0,
+            "name": "Alcedo vintsioides"
+        },
+        {
+            "id": 1,
+            "name": "Alcedo cristata"
+        },
+        {
+            "id": 2,
+            "name": "Alcedo leucogaster"
+        },
+        {
+            "id": 3,
+            "name": "Ceyx madagascariensis"
+        },
+        {
+            "id": 4,
+            "name": "Ceyx lecontei"
+        },
+        {
+            "id": 5,
+            "name": "Ceyx pictus"
+        },
+        {
+            "id": 6,
+            "name": "Alcedo meninting"
+        },
+        {
+            "id": 7,
+            "name": "Alcedo hercules"
+        },
+        {
+            "id": 8,
+            "name": "Alcedo semitorquata"
+        },
+        {
+            "id": 9,
+            "name": "Alcedo quadribrachys"
+        },
+        {
+            "id": 10,
+            "name": "Alcedo coerulescens"
+        },
+        {
+            "id": 11,
+            "name": "Alcedo atthis"
+        },
+        {
+            "id": 12,
+            "name": "Alcedo euryzona"
+        },
+        {
+            "id": 13,
+            "name": "Alcedo azurea"
+        },
+        {
+            "id": 14,
+            "name": "Alcedo websteri"
+        },
+        {
+            "id": 15,
+            "name": "Alcedo pusilla"
+        },
+        {
+            "id": 16,
+            "name": "Ceyx rufidorsa"
+        },
+        {
+            "id": 17,
+            "name": "Ceyx erithaca"
+        },
+        {
+            "id": 18,
+            "name": "Alcedo argentata"
+        },
+        {
+            "id": 19,
+            "name": "Alcedo cyanopectus"
+        },
+        {
+            "id": 20,
+            "name": "Ceyx lepidus"
+        },
+        {
+            "id": 21,
+            "name": "Ceyx melanurus"
+        },
+        {
+            "id": 22,
+            "name": "Ceyx fallax"
+        },
+        {
+            "id": 23,
+            "name": "Lacedo pulchella"
+        },
+        {
+            "id": 24,
+            "name": "Halcyon badia"
+        },
+        {
+            "id": 25,
+            "name": "Halcyon malimbica"
+        },
+        {
+            "id": 26,
+            "name": "Halcyon senegalensis"
+        },
+        {
+            "id": 27,
+            "name": "Halcyon leucocephala"
+        },
+        {
+            "id": 28,
+            "name": "Pelargopsis capensis"
+        },
+        {
+            "id": 29,
+            "name": "Halcyon coromanda"
+        },
+        {
+            "id": 30,
+            "name": "Dacelo leachii"
+        },
+        {
+            "id": 31,
+            "name": "Dacelo novaeguineae"
+        },
+        {
+            "id": 32,
+            "name": "Dacelo gaudichaud"
+        },
+        {
+            "id": 33,
+            "name": "Clytoceyx rex"
+        },
+        {
+            "id": 34,
+            "name": "Melidora macrorrhina"
+        },
+        {
+            "id": 35,
+            "name": "Cittura cyanotis"
+        },
+        {
+            "id": 36,
+            "name": "Tanysiptera galatea"
+        },
+        {
+            "id": 37,
+            "name": "Actenoides concretus"
+        },
+        {
+            "id": 38,
+            "name": "Actenoides lindsayi"
+        },
+        {
+            "id": 39,
+            "name": "Todiramphus winchelli"
+        },
+        {
+            "id": 40,
+            "name": "Todiramphus leucopygius"
+        },
+        {
+            "id": 41,
+            "name": "Todiramphus sanctus"
+        },
+        {
+            "id": 42,
+            "name": "Todiramphus chloris"
+        },
+        {
+            "id": 43,
+            "name": "Todiramphus macleayii"
+        },
+        {
+            "id": 44,
+            "name": "Todiramphus tutus"
+        },
+        {
+            "id": 45,
+            "name": "Syma torotoro"
+        },
+        {
+            "id": 46,
+            "name": "Megaceryle maxima"
+        },
+        {
+            "id": 47,
+            "name": "Megaceryle alcyon"
+        },
+        {
+            "id": 48,
+            "name": "Megaceryle torquata"
+        },
+        {
+            "id": 49,
+            "name": "Ceryle rudis"
+        },
+        {
+            "id": 50,
+            "name": "Chloroceryle amazona"
+        },
+        {
+            "id": 51,
+            "name": "Chloroceryle aenea"
+        },
+        {
+            "id": 52,
+            "name": "Chloroceryle americana"
+        },
+        {
+            "id": 53,
+            "name": "Chloroceryle inda"
+        }
+    ],
+    "trees": [
+        {
+            "name": "UNTITLED",
+            "root": {
+                "branch_length": -1.0,
+                "children": [
+                    {
+                        "branch_length": 21.46725228,
+                        "children": [
+                            {
+                                "branch_length": 1.128798874,
+                                "children": [
+                                    {
+                                        "branch_length": 6.708299964,
+                                        "children": [
+                                            {
+                                                "branch_length": 5.635787971,
+                                                "children": [],
+                                                "taxon": 4
+                                            },
+                                            {
+                                                "branch_length": 5.635787971,
+                                                "children": [],
+                                                "taxon": 5
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "branch_length": 2.907462622,
+                                        "children": [
+                                            {
+                                                "branch_length": 9.436625313,
+                                                "children": [],
+                                                "taxon": 3
+                                            },
+                                            {
+                                                "branch_length": 1.840724236,
+                                                "children": [
+                                                    {
+                                                        "branch_length": 7.595901077,
+                                                        "children": [],
+                                                        "taxon": 2
+                                                    },
+                                                    {
+                                                        "branch_length": 2.807879302,
+                                                        "children": [
+                                                            {
+                                                                "branch_length": 4.788021775,
+                                                                "children": [],
+                                                                "taxon": 0
+                                                            },
+                                                            {
+                                                                "branch_length": 4.788021775,
+                                                                "children": [],
+                                                                "taxon": 1
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "branch_length": 0.9209627144,
+                                "children": [
+                                    {
+                                        "branch_length": 2.229493501,
+                                        "children": [
+                                            {
+                                                "branch_length": 10.32243059,
+                                                "children": [],
+                                                "taxon": 12
+                                            },
+                                            {
+                                                "branch_length": 2.506740623,
+                                                "children": [
+                                                    {
+                                                        "branch_length": 3.881486094,
+                                                        "children": [
+                                                            {
+                                                                "branch_length": 3.934203877,
+                                                                "children": [],
+                                                                "taxon": 6
+                                                            },
+                                                            {
+                                                                "branch_length": 3.934203877,
+                                                                "children": [],
+                                                                "taxon": 7
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "branch_length": 1.530793613,
+                                                        "children": [
+                                                            {
+                                                                "branch_length": 3.133096404,
+                                                                "children": [
+                                                                    {
+                                                                        "branch_length": 3.151799953,
+                                                                        "children": [],
+                                                                        "taxon": 8
+                                                                    },
+                                                                    {
+                                                                        "branch_length": 3.151799953,
+                                                                        "children": [],
+                                                                        "taxon": 9
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "branch_length": 1.230348501,
+                                                                "children": [
+                                                                    {
+                                                                        "branch_length": 5.054547857,
+                                                                        "children": [],
+                                                                        "taxon": 10
+                                                                    },
+                                                                    {
+                                                                        "branch_length": 5.054547857,
+                                                                        "children": [],
+                                                                        "taxon": 11
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "branch_length": 1.683569247,
+                                        "children": [
+                                            {
+                                                "branch_length": 10.86835485,
+                                                "children": [],
+                                                "taxon": 22
+                                            },
+                                            {
+                                                "branch_length": 2.602871595,
+                                                "children": [
+                                                    {
+                                                        "branch_length": 3.278445089,
+                                                        "children": [
+                                                            {
+                                                                "branch_length": 4.987038163,
+                                                                "children": [],
+                                                                "taxon": 15
+                                                            },
+                                                            {
+                                                                "branch_length": 3.467632109,
+                                                                "children": [
+                                                                    {
+                                                                        "branch_length": 1.519406055,
+                                                                        "children": [],
+                                                                        "taxon": 13
+                                                                    },
+                                                                    {
+                                                                        "branch_length": 1.519406055,
+                                                                        "children": [],
+                                                                        "taxon": 14
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "branch_length": 2.169030232,
+                                                        "children": [
+                                                            {
+                                                                "branch_length": 6.096453021,
+                                                                "children": [],
+                                                                "taxon": 21
+                                                            },
+                                                            {
+                                                                "branch_length": 0.5031459505,
+                                                                "children": [
+                                                                    {
+                                                                        "branch_length": 4.963043774,
+                                                                        "children": [
+                                                                            {
+                                                                                "branch_length": 0.6302632958,
+                                                                                "children": [],
+                                                                                "taxon": 16
+                                                                            },
+                                                                            {
+                                                                                "branch_length": 0.6302632958,
+                                                                                "children": [],
+                                                                                "taxon": 17
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "branch_length": 1.860375066,
+                                                                        "children": [
+                                                                            {
+                                                                                "branch_length": 3.732932004,
+                                                                                "children": [],
+                                                                                "taxon": 20
+                                                                            },
+                                                                            {
+                                                                                "branch_length": 1.77035215,
+                                                                                "children": [
+                                                                                    {
+                                                                                        "branch_length": 1.962579854,
+                                                                                        "children": [],
+                                                                                        "taxon": 18
+                                                                                    },
+                                                                                    {
+                                                                                        "branch_length": 1.962579854,
+                                                                                        "children": [],
+                                                                                        "taxon": 19
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "branch_length": 2.794262429,
+                        "children": [
+                            {
+                                "branch_length": 9.319652147,
+                                "children": [
+                                    {
+                                        "branch_length": 10.3575263,
+                                        "children": [
+                                            {
+                                                "branch_length": 12.46869821,
+                                                "children": [],
+                                                "taxon": 46
+                                            },
+                                            {
+                                                "branch_length": 7.934277201,
+                                                "children": [
+                                                    {
+                                                        "branch_length": 4.534421013,
+                                                        "children": [],
+                                                        "taxon": 47
+                                                    },
+                                                    {
+                                                        "branch_length": 4.534421013,
+                                                        "children": [],
+                                                        "taxon": 48
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "branch_length": 2.138554581,
+                                        "children": [
+                                            {
+                                                "branch_length": 20.68766993,
+                                                "children": [],
+                                                "taxon": 49
+                                            },
+                                            {
+                                                "branch_length": 6.828901682,
+                                                "children": [
+                                                    {
+                                                        "branch_length": 13.85876825,
+                                                        "children": [],
+                                                        "taxon": 50
+                                                    },
+                                                    {
+                                                        "branch_length": 4.458266963,
+                                                        "children": [
+                                                            {
+                                                                "branch_length": 9.40050129,
+                                                                "children": [],
+                                                                "taxon": 51
+                                                            },
+                                                            {
+                                                                "branch_length": 3.094073469,
+                                                                "children": [
+                                                                    {
+                                                                        "branch_length": 6.306427821,
+                                                                        "children": [],
+                                                                        "taxon": 52
+                                                                    },
+                                                                    {
+                                                                        "branch_length": 6.306427821,
+                                                                        "children": [],
+                                                                        "taxon": 53
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "branch_length": 8.402877069,
+                                "children": [
+                                    {
+                                        "branch_length": 23.74299959,
+                                        "children": [],
+                                        "taxon": 23
+                                    },
+                                    {
+                                        "branch_length": 3.374889887,
+                                        "children": [
+                                            {
+                                                "branch_length": 5.079713983,
+                                                "children": [
+                                                    {
+                                                        "branch_length": 15.28839572,
+                                                        "children": [],
+                                                        "taxon": 28
+                                                    },
+                                                    {
+                                                        "branch_length": 3.74766945,
+                                                        "children": [
+                                                            {
+                                                                "branch_length": 11.54072627,
+                                                                "children": [],
+                                                                "taxon": 27
+                                                            },
+                                                            {
+                                                                "branch_length": 3.089675212,
+                                                                "children": [
+                                                                    {
+                                                                        "branch_length": 8.451051062,
+                                                                        "children": [],
+                                                                        "taxon": 24
+                                                                    },
+                                                                    {
+                                                                        "branch_length": 4.230993416,
+                                                                        "children": [
+                                                                            {
+                                                                                "branch_length": 4.220057646,
+                                                                                "children": [],
+                                                                                "taxon": 25
+                                                                            },
+                                                                            {
+                                                                                "branch_length": 4.220057646,
+                                                                                "children": [],
+                                                                                "taxon": 26
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "branch_length": 3.539705202,
+                                                "children": [
+                                                    {
+                                                        "branch_length": 1.819899738,
+                                                        "children": [
+                                                            {
+                                                                "branch_length": 6.394418017,
+                                                                "children": [
+                                                                    {
+                                                                        "branch_length": 8.614086751,
+                                                                        "children": [],
+                                                                        "taxon": 37
+                                                                    },
+                                                                    {
+                                                                        "branch_length": 8.614086751,
+                                                                        "children": [],
+                                                                        "taxon": 38
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "branch_length": 3.950042596,
+                                                                "children": [
+                                                                    {
+                                                                        "branch_length": 11.05846217,
+                                                                        "children": [],
+                                                                        "taxon": 45
+                                                                    },
+                                                                    {
+                                                                        "branch_length": 2.270011677,
+                                                                        "children": [
+                                                                            {
+                                                                                "branch_length": 8.788450495,
+                                                                                "children": [],
+                                                                                "taxon": 39
+                                                                            },
+                                                                            {
+                                                                                "branch_length": 5.002287961,
+                                                                                "children": [
+                                                                                    {
+                                                                                        "branch_length": 3.786162534,
+                                                                                        "children": [],
+                                                                                        "taxon": 40
+                                                                                    },
+                                                                                    {
+                                                                                        "branch_length": 2.072102611,
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "branch_length": 0.7298910596,
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "branch_length": 0.9841688636,
+                                                                                                        "children": [],
+                                                                                                        "taxon": 41
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "branch_length": 0.9841688636,
+                                                                                                        "children": [],
+                                                                                                        "taxon": 42
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            {
+                                                                                                "branch_length": 0.6650978634,
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "branch_length": 1.04896206,
+                                                                                                        "children": [],
+                                                                                                        "taxon": 43
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "branch_length": 1.04896206,
+                                                                                                        "children": [],
+                                                                                                        "taxon": 44
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "branch_length": 1.431678775,
+                                                        "children": [
+                                                            {
+                                                                "branch_length": 4.239866986,
+                                                                "children": [
+                                                                    {
+                                                                        "branch_length": 11.15685875,
+                                                                        "children": [],
+                                                                        "taxon": 35
+                                                                    },
+                                                                    {
+                                                                        "branch_length": 11.15685875,
+                                                                        "children": [],
+                                                                        "taxon": 36
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "branch_length": 2.778867612,
+                                                                "children": [
+                                                                    {
+                                                                        "branch_length": 12.61785812,
+                                                                        "children": [],
+                                                                        "taxon": 29
+                                                                    },
+                                                                    {
+                                                                        "branch_length": 0.2353329916,
+                                                                        "children": [
+                                                                            {
+                                                                                "branch_length": 12.38252513,
+                                                                                "children": [],
+                                                                                "taxon": 34
+                                                                            },
+                                                                            {
+                                                                                "branch_length": 6.3388744,
+                                                                                "children": [
+                                                                                    {
+                                                                                        "branch_length": 6.043650727,
+                                                                                        "children": [],
+                                                                                        "taxon": 33
+                                                                                    },
+                                                                                    {
+                                                                                        "branch_length": 2.943500596,
+                                                                                        "children": [
+                                                                                            {
+                                                                                                "branch_length": 3.100150132,
+                                                                                                "children": [],
+                                                                                                "taxon": 32
+                                                                                            },
+                                                                                            {
+                                                                                                "branch_length": 1.199588818,
+                                                                                                "children": [
+                                                                                                    {
+                                                                                                        "branch_length": 1.900561313,
+                                                                                                        "children": [],
+                                                                                                        "taxon": 30
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "branch_length": 1.900561313,
+                                                                                                        "children": [],
+                                                                                                        "taxon": 31
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        ]
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    ],
+    "version": "1.0"
+}

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+setup(
+    name='treeppl',
+    version='0.1',
+    description='Python Interface to TreePPL',
+    author='Jan Kudlicka',
+    author_email='github@kudlicka.eu',
+    packages=['treeppl'],
+    install_requires=[
+        'numpy',
+    ],
+)

--- a/python/treeppl/__init__.py
+++ b/python/treeppl/__init__.py
@@ -1,0 +1,3 @@
+from .base import Model, InferenceResult
+from .exceptions import CompileError, InferenceError
+from .serialization import Object, constructor

--- a/python/treeppl/base.py
+++ b/python/treeppl/base.py
@@ -1,0 +1,74 @@
+import json
+from tempfile import TemporaryDirectory
+from subprocess import Popen, PIPE, STDOUT
+import numpy as np
+
+from .exceptions import CompileError, InferenceError
+from .serialization import from_json, to_json
+
+
+class Model:
+    def __init__(self, source=None, filename=None, method="smc-bpf", samples=1_000, **kwargs):
+        self.temp_dir = TemporaryDirectory(prefix="treeppl_")
+        if filename:
+            source = open(filename).read()
+        if not source:
+            raise CompileError("No source code to compile.")
+        with open(self.temp_dir.name + "/__main__.tppl", "w") as f:
+            f.write(source)
+        args = [
+            "tpplc",
+            "__main__.tppl",
+            "-m", method,
+        ]
+        for k, v in kwargs.items():
+            args.append(f"--{k.replace('_', '-')}")
+            args.append(str(v))
+        with Popen(
+            args=args,
+            cwd=self.temp_dir.name,
+            stdout=PIPE,
+            stderr=STDOUT
+        ) as proc:
+            proc.wait()
+            if proc.returncode != 0:
+                output = proc.stdout.read().decode('utf-8')
+                output = output.replace("__main__.tppl", "source code")
+                raise CompileError(f"Could not compile the TreePPL model:\n{output}")
+        self.set_samples(samples)
+
+    def set_samples(self, samples):
+        self.samples = samples
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.temp_dir.cleanup()
+
+    def __call__(self, **kwargs):
+        with open(self.temp_dir.name + "/input.json", "w") as f:
+            to_json(kwargs or {}, f)
+        args = [
+            f"{self.temp_dir.name}/out",
+            f"{self.temp_dir.name}/input.json",
+            str(self.samples)
+        ]
+        with Popen(args=args, stdout=PIPE) as proc:
+            return InferenceResult(proc.stdout)
+
+            
+class InferenceResult:
+    def __init__(self, stdout):
+        try:
+            result = from_json(stdout)
+        except json.decoder.JSONDecodeError:
+            raise InferenceError("Could not parse the output from TreePPL.")
+        self.samples = result.get('samples', [])
+        self.weights = np.array(result.get('weights', []))
+        self.nweights = np.exp(self.weights)
+        self.norm_const = result.get('normConst', np.nan)
+
+    def subsample(self, size=1):
+        idx = np.random.choice(len(self.nweights), size, p=self.nweights)
+        return [self.samples[i] for i in idx]

--- a/python/treeppl/exceptions.py
+++ b/python/treeppl/exceptions.py
@@ -1,0 +1,8 @@
+class CompileError(Exception):
+    pass
+
+class InferenceError(Exception):
+    pass
+
+class SerializationError(Exception):
+    pass

--- a/python/treeppl/serialization.py
+++ b/python/treeppl/serialization.py
@@ -1,0 +1,66 @@
+import json
+import numpy as np
+
+from .exceptions import SerializationError
+
+
+constructor_to_class = {}
+class_to_constructor = {}
+
+
+class Object:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def object_hook(dictionary):
+    if "__constructor__" in dictionary:
+        constructor = dictionary["__constructor__"]
+        if constructor not in constructor_to_class:
+            constructor_to_class[constructor] = type(constructor, (Object,), {})
+            class_to_constructor[constructor_to_class[constructor]] = constructor
+        return constructor_to_class[constructor](**dictionary.get("__data__", {}))
+    if "__float__" in dictionary:
+        return float(dictionary["__float__"])
+    if "__tensor__" in dictionary:
+        return np.array(dictionary["__tensor__"]).reshape(dictionary["__tensorShape__"])
+    return dictionary
+
+
+def constructor(name):
+    def wrapper(cls):
+        constructor_to_class[name] = cls
+        class_to_constructor[cls] = name
+        return cls
+    return wrapper
+
+
+def from_json(fp):
+    return json.load(fp, object_hook=object_hook)
+
+
+class JSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        try:
+            if isinstance(obj, np.ndarray):
+                return {
+                    "__tensor__": obj.flatten().tolist(),
+                    "__tensorShape__": obj.shape
+                }
+            return json.JSONEncoder.default(self, obj)
+        except TypeError:
+            try:
+                return {
+                    "__constructor__": class_to_constructor.get(
+                        obj.__class__,
+                        obj.__class__.__name__
+                    ),
+                    "__data__": vars(obj)
+                }
+            except:
+                raise SerializationError("Could not serialize the data.")
+
+
+def to_json(value, fp):
+    return json.dump(value, fp, cls=JSONEncoder)


### PR DESCRIPTION
Install the package:

```shell
pip install "git+https://github.com/kudlicka/treeppl#egg=treeppl&subdirectory=python"
```

Example of use:

```python
import treeppl
import numpy as np
import matplotlib.pyplot as plt
import seaborn as sns

# Define a TreePPL model source code
source = """\
model function coin(outcomes: Bool[]): Real {
  assume p ~ Beta(2.0, 2.0);
  for i in 1 to (length(outcomes)) {
    observe outcomes[i] ~ Bernoulli(p);
  }
  return(p);
}
"""

# Create a TreePPL model instance
with treeppl.Model(source=source, samples=10_000) as coin:
    # Run the inference on the model
    res = coin(outcomes=[True, True, True, False, True, False, False, True, True, False, False, False, True, False, True, False, False, True, False, False])
    
    # Visualize the results using Seaborn and Matplotlib
    sns.histplot(x=res.samples, weights=res.nweights, bins=100, stat="density", kde=True)
    plt.show()
```

Parameters of `treeppl.Model()`:

- `source`: The source code of a TreePPL model.
- `filename`: The name of the TreePPL model file.
- `method`: The inference method to be used, with 'smc-bpf' as the default.
- `samples`: The number of samples to collect, with a default of 1,000.
- Any additional named parameters will be passed as additional arguments to `tpplc`. For example, `stack_size=10000` will add `--stack-size 10000` to the arguments of `tpplc`.

Please note that either `source` or `filename` must be specified when creating a `treeppl.Model` instance.

`treeppl.Model()` returns an instance that can be called directly to run inference, specifying the model's arguments as named parameters, as shown in the example above.

The return value is an instance of `treeppl.InferenceResult`, which includes the following properties:

- `samples`: The samples returned from TreePPL.
- `weights`: The log-weights of the samples.
- `nweights`: The normalized weights of the samples.
- `norm_const`: The logarithm of the marginal likelihood.