### PR TITLE
Refactoring Mariana's additions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@ uninstall:
 	rm ${bin_path}/${tppl_name}
 	rm -rf $(src_path)
 
+libtest:
+	mi compile src/lib/standard.mc --test
+	./standard
+	@echo 
+	rm -f standard
+
 # Filtering successful tests
 test: src/treeppl-to-coreppl/compile.mc
 	mi compile src/treeppl-to-coreppl/compile.mc --test

--- a/src/lib/standard.mc
+++ b/src/lib/standard.mc
@@ -300,5 +300,5 @@ let __test_messageElemPow = messageElemPow __test_message 2.
 utest tensorToSeqExn (tensorSliceExn (get __test_messageElemPow 0) [0]) with [4., 9.]
   using (eqSeq eqf)
 
-  utest tensorToSeqExn (tensorSliceExn (get __test_messageElemPow 1) [0]) with [16., 25.]
+utest tensorToSeqExn (tensorSliceExn (get __test_messageElemPow 1) [0]) with [16., 25.]
   using (eqSeq eqf)

--- a/src/lib/standard.mc
+++ b/src/lib/standard.mc
@@ -260,11 +260,6 @@ let normalizeVec = lam v.
   let sum = tensorFold addf 0. v in
   tensorCreateCArrayFloat (tensorShape v) (lam i. divf (tensorGetExn v i) sum)
 
--- Message normalization 
--- TODO(vsenderov, 2023-11-02): This should not be in the Miking file, but rather in TPPL file
-let normalizeMessage = lam m. 
-  map normalizeVector m
-
 -- Elementwise multiplication of state likelihoods/probabilities
 -- TODO(vsenderov, 2023-11-02): This should not be in the Miking file, but rather in TPPL file
 let mulMessage = zipWith matrixElemMul

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -182,7 +182,8 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + MExprFindSym + RecLetsAst + Extern
     matrixMul: Name,
     matrixPow: Name,
     matrixAdd: Name,
-    matrixMulFloat: Name
+    matrixMulFloat: Name,
+    pow: Name
   }
 
   sem isemi_: Expr -> Expr -> Expr
@@ -263,8 +264,8 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + MExprFindSym + RecLetsAst + Extern
     match findNamesOfStringsExn [
       "serializeResult", "externalLog", "externalExp", "json2string",
       "particles", "sweeps", "input", "Some", "matrixMul", "mtxPow", "matrixElemAdd",
-      "matrixMulFloat"
-    ] libCompile with [sr, el, ee, j2s, p, sw, i, s, mm, mp, ma, mmf] in
+      "matrixMulFloat", "pow"
+    ] libCompile with [sr, el, ee, j2s, p, sw, i, s, mm, mp, ma, mmf, po] in
     let cc: TpplCompileContext = {
       serializeResult = sr,
       logName = el, expName = ee,
@@ -276,7 +277,8 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + MExprFindSym + RecLetsAst + Extern
       matrixMul = mm,
       matrixPow = mp,
       matrixAdd = ma,
-      matrixMulFloat = mmf
+      matrixMulFloat = mmf,
+      pow = po
     } in
 
     let tpplLibLoc = (concat tpplSrcLoc "/lib/standard.tppl") in
@@ -1027,6 +1029,19 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + MExprFindSym + RecLetsAst + Extern
         ty = tyunknown_
       }
 
+  | PowerExprTppl x ->
+   TmApp {
+        info = x.info,
+        lhs = TmApp {
+          info = x.info,
+          lhs = nvar_ context.pow,
+          rhs = compileExprTppl context x.left,
+          ty = tyunknown_
+        },
+        rhs = compileExprTppl context x.right,
+        ty = tyunknown_
+      }
+        
   | MatrixLeftScalarMulExprTppl x ->
     TmApp {
         info = x.info,

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -144,6 +144,9 @@ prod left Sub: ExprTppl = left:ExprTppl "-" right:ExprTppl
 prod Neg: ExprTppl = "-" right:ExprTppl
 -- infix Division: Expr = "/"
 prod left Div: ExprTppl = left:ExprTppl "/" right:ExprTppl
+-- Power: Expr = "^"
+prod left Power: ExprTppl = left:ExprTppl "^" right:ExprTppl
+
 -- is
 prod Is: ExprTppl = thing:ExprTppl "is" constructor:UName
 -- to
@@ -187,7 +190,7 @@ prod Projection: ExprTppl = target:ExprTppl "." field:LIdent
 
 precedence {
   Projection FunCall Subscript;
-  Not;
+  Not Neg;
   Mul Div;
   Add Sub;
   ~Less Greater LessEq GreaterEq Equal Unequal;


### PR DESCRIPTION
## Extensions that Mariana did for the host-repertoire model, somewhat refactored

I changed some things.  

 - renamed `normalizeSeq` to `normalizeRealSeq` as it made sense.
 
- renamed `normalizeVector` to `normalizeVec` and put a TODO that we have to write unit tests.
 
- `normalizeMessage` and `mulMessage` should not be "shipped" like this, instead they should be implemented in TPPL.
 
- Finally `messageElementPower` I broke up in two.  
 
- a new function `mtxElemPow`
 - rewrote `messageElementPower` to use it.
 - similar to `normalizeMessage and `mulMessage` it should be done in the TPPL file.