### PR TITLE
Type annotations on `let` and `assume`

### DIFF
--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -554,7 +554,7 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + MExprFindSym + RecLetsAst + Extern
     lam cont. TmLet {
       ident = a.randomVar.v,
       tyBody = tyunknown_,
-      tyAnnot = tyunknown_,
+      tyAnnot = optionMapOr tyunknown_ compileTypeTppl a.ty,
       body = TmAssume {
         dist = compileExprTppl context a.dist,
         ty = tyunknown_,
@@ -585,7 +585,7 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + MExprFindSym + RecLetsAst + Extern
     lam cont. TmLet {
       ident = a.var.v,
       tyBody = tyunknown_,
-      tyAnnot = tyunknown_,
+      tyAnnot = optionMapOr tyunknown_ compileTypeTppl a.ty,
       body =  compileExprTppl context a.val,
       inexpr = cont,
       ty = tyunknown_,

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -220,8 +220,8 @@ prod Constructor: ExprTppl =
 
 /----- Statements -----/
 prod ExprStmtTppl: StmtTppl = e:ExprTppl ";" -- Epxressions as statements
-prod Assume: StmtTppl = "assume" randomVar:LName "~" dist:ExprTppl ";"
-prod Assign: StmtTppl = "let" var:LName "=" val:ExprTppl ";"
+prod Assume: StmtTppl = "assume" randomVar:LName (":" ty:TypeTppl)? "~" dist:ExprTppl ";"
+prod Assign: StmtTppl = "let" var:LName (":" ty:TypeTppl)? "=" val:ExprTppl ";"
 --prod Observe: StmtTppl = "observe" value:ExprTppl "~" distribution:UName "(" (args:ExprTppl ("," args:ExprTppl)*)? ")"
 prod Observe: StmtTppl = "observe" value:ExprTppl "~" dist:ExprTppl ";"
 prod Resample: StmtTppl = "resample" ";"


### PR DESCRIPTION
This PR adds the ability to put explicit type-annotations on `let`s and `assume`s. Example:

```
let a : String = "some text";
assume x : Real ~ Uniform(1.0, 2.0);
```