### PR TITLE
Properly compiles types from the standard library

### DIFF
--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -264,7 +264,6 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + MExprFindSym + RecLetsAst + Extern
     let tpplLibLoc = (concat tpplSrcLoc "/lib/standard.tppl") in
     let tpplLibContent = readFile tpplLibLoc in
     match parseTreePPLExn tpplLibLoc tpplLibContent with tpplLibFile in
-    --let tpplLibAst: Expr = compileFunctionsOnly cc tpplLibFile in
     match (compileFunctionsOnly cc tpplLibFile) with [libTypes, libFunctions] in
 
     -- Compile the model function
@@ -347,7 +346,6 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + MExprFindSym + RecLetsAst + Extern
     let complete = bindall_ (join
       [ [ stdlib
         , libCompile
-        --, tpplLibAst
         , types
         , functions
         , libFunctions


### PR DESCRIPTION
Fixes a bug in the library compilation of `standard.tppl`, which did not properly expose the types defined in it.