### PR TITLE
Operator overloading skeleton

### DIFF
--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -135,7 +135,7 @@ prod Sequence: ExprTppl = "[" (values:ExprTppl ("," values:ExprTppl)*)? "]"
 
 
 -- infix left Addition: Expr = "+"
-prod left Add: ExprTppl = left:ExprTppl "+" right:ExprTppl
+prod left Add: ExprTppl = left:ExprTppl op:"+" right:ExprTppl
 -- infix Multiplication: Expr = "*"
 prod left Mul: ExprTppl = left:ExprTppl "*" right:ExprTppl
 -- inflix Subtraction: Expr = "-"
@@ -156,7 +156,7 @@ prod left Less: ExprTppl = left:ExprTppl "<" right:ExprTppl
 prod left Greater: ExprTppl = left:ExprTppl ">" right:ExprTppl
 prod left LessEq: ExprTppl = left:ExprTppl "<=" right:ExprTppl
 prod left GreaterEq: ExprTppl = left:ExprTppl ">=" right:ExprTppl
-prod left Equal: ExprTppl = left:ExprTppl "==" right:ExprTppl -- currently implemented as floats which doesn't make much sense
+prod left Equal: ExprTppl = left:ExprTppl op:"==" right:ExprTppl -- currently implemented as floats which doesn't make much sense
 prod left Unequal: ExprTppl = left:ExprTppl "!=" right:ExprTppl
 -- Boolean operators
 infix left And: ExprTppl = "&&"


### PR DESCRIPTION
This PR contains code implementing the approach I reasoned should be enough for what we need for operator overloading for the moment, with just two operators implemented for now (`+` and `==`) as proof of concept.

I'm hoping that someone else can take over and fill out the remaining operators, since it should be fairly mechanical work. Probably easiest to pull this branch, do the work, then open a new PR instead of this one.

Things to do to add support for an operator:
- Add a constructor to `BinOp`, likely in the `OverloadedMath` language fragment. I've added the basic ones (arithmetic + comparisons).
- Ensure it is covered by `sem binOpMkTypes`. I've done this for the constructors already present in `BinOp`.
- Add cases to `sem resolveBinOp` as needed. These should check which operator it is, and what types have been inferred, then construct a new `Expr` that implements the operator. Here I've only added cases for `BOAdd` and `BOEq`, for both `TyInt` and `TyFloat`.
- Ensure `compileExprTppl` uses `mkBinOp` to construct its operators rather than a `TmConst` with some particular function. I've made this change for addition and equality. I also took the liberty of capturing the `Info` for the operator itself as `op` in the `.syn` file, to get a more precise pointer in case of errors.