### PR TITLE
Fix Availability of Standard Library Functions in User Programs

### DIFF
--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -347,8 +347,8 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + MExprFindSym + RecLetsAst + Extern
       [ [ stdlib
         , libCompile
         , types
-        , functions
         , libFunctions
+        , functions
         , inputR
         ]
       , inputArgs


### PR DESCRIPTION
**Problem**

User programs were unable to access functions defined in the standard library due to an issue in how the compiler integrated and exposed these functions. This led to errors where user programs would fail to recognize or call standard library functions, significantly limiting functionality.

**Solution**

This PR addresses the issue by adjusting the order and method of inclusion for standard library functions within the compiler's output generation process. Specifically, it ensures that:

- Types from the standard library are defined before any functions, allowing all functions to properly reference these types.
- Standard library functions (`libFunctions`) are included before user-defined functions but after types, ensuring these functions are available and correctly scoped for use in user programs.

**Impact**

With these changes, standard library functions are now correctly available to user programs, as verified by the successful passing of previously failing tests, thus fixing issue #56 
