### PR TITLE
Anonymous functions

### DIFF
--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -698,6 +698,17 @@ lang TreePPLCompile = TreePPLAst + MExprPPL + MExprFindSym + RecLetsAst + Extern
 
   sem compileExprTppl (context: TpplCompileContext) =
 
+  | AnonFunExprTppl x ->
+    let args = if null x.args
+      then [(nameNoSym "", tyint_)]
+      else map (lam a. (a.name.v, compileTypeTppl a.ty)) x.args in
+    let body = foldr (lam f. lam e. f e)
+      (withInfo x.info unit_)
+      (map (compileStmtTppl context) x.stmts) in
+    let wrap = lam pair. lam body.
+      withInfo x.info (nlam_ pair.0 pair.1 body) in
+    foldr wrap body args
+
   | ProjectionExprTppl x ->
     TmProjMatch {
       info = x.info,

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -183,6 +183,12 @@ prod left MatrixPower: ExprTppl = left:ExprTppl "^$" right:ExprTppl -- imagined 
 
   -- because the right has to be an integer not another matrix
 
+-- Anonymous functions
+
+prod AnonFun: ExprTppl = "function"
+  "(" (args:{name:LName ":" ty:TypeTppl} args:{"," name:LName ":" ty:TypeTppl}*)? ")"
+  "{" stmts:StmtTppl* "}"
+
 -- Function call as expression
 prod FunCall: ExprTppl = f:ExprTppl "(" (args:ExprTppl ("," args:ExprTppl)*)? ")"
 


### PR DESCRIPTION
## Syntax
```
function (arg: Type, arg: Type, ...) {
  // Body of the anonymous function
}
```

## Example of usage:
```
function example() {
  let c = 10;
  let x = sapply(1 to 5, function (i: Int) {
    return addi(c, i);
  });
}
```

## Acknowledgements
Thanks to Viktor Palmkvist for a sketch of the implementation.