### PR TITLE
Custom drift kernels + updates following miking-dppl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ TEST_CONFIGURATIONS += -m_mcmc-lightweight_--cps_none #resample
 TEST_CONFIGURATIONS += -m_mcmc-lightweight_--align_--cps_none #resample
 TEST_CONFIGURATIONS += -m_mcmc-lightweight_--align_--cps_full #resample
 TEST_CONFIGURATIONS += -m_mcmc-lightweight_--align_--cps_partial #resample
-TEST_CONFIGURATIONS += -m_mcmc-trace_--cps_none
-TEST_CONFIGURATIONS += -m_mcmc-naive_--cps_none
+TEST_CONFIGURATIONS += -m_mcmc-trace
+TEST_CONFIGURATIONS += -m_mcmc-naive
 TEST_CONFIGURATIONS += -m_pmcmc-pimh_--cps_full
 TEST_CONFIGURATIONS += -m_pmcmc-pimh_--cps_partial
 

--- a/src/tpplc.mc
+++ b/src/tpplc.mc
@@ -20,25 +20,70 @@ include "coreppl::parser.mc"
 
 
 
--- Command line menu for TreePPL
-let tpplMenu = lam. join [
-  "Usage: tpplc program.tppl [<options>]\n\n",
-  "Options:\n",
-  argHelpOptions config,
-  "\n"
-]
-
 mexpr
 
--- Use the arg.mc library to parse arguments
-let result = argParse defaultArgs config in
-match result with ParseOK r then
-  let options: Options = r.options in
-  -- Print menu if not exactly one file argument
-  if neqi (length r.strings) 1 then
-    print (tpplMenu ());
-    if gti (length r.strings) 1 then exit 1 else exit 0
-  else
-    match r.strings with [filename] in
-    compileTpplToExecutable filename options
-else argPrintError result
+use TreePPLThings in
+
+let mcmcLightweightOptions : OptParser (Type -> Loader -> (Loader, InferMethod)) =
+  let mk = lam thinPeriod. lam incrementalPrinting. lam iterations. lam globalProb. lam driftKernel. lam driftScale. lam cps. lam align. lam outputType. lam loader.
+    match includeFileExn "." "stdlib::json.mc" loader with (jsonEnv, loader) in
+    match serializationPairsFor [outputType] loader with (loader, [outputSer]) in
+    let keepSample = if incrementalPrinting
+      then ulam_ "" false_
+      else if eqi 1 thinPeriod
+        then ulam_ "" true_
+        else ulam_ "idx" (eqi_ (int_ 0) (modi_ (var_ "idx") (int_ thinPeriod))) in
+    let continue =
+      let ret = utuple_ [addi_ (var_ "idx") (int_ 1), neqi_ (var_ "idx") (int_ iterations)] in
+      let ret =
+        if incrementalPrinting then
+          let print = app_ (nvar_ (_getVarExn "printJsonLn" jsonEnv)) (app_ outputSer.serializer (var_ "sample")) in
+          let print = if eqi thinPeriod 1
+            then print
+            else if_ (eqi_ (int_ 0) (modi_ (var_ "idx") (int_ thinPeriod))) print unit_ in
+          semi_ print ret
+        else ret in
+      utuple_ [int_ 0, ulam_ "idx" (ulam_ "sample" ret)] in
+    let method = LightweightMCMC
+      { keepSample = keepSample
+      , continue = continue
+      , globalProb = float_ globalProb
+      , driftKernel = driftKernel
+      , driftScale = driftScale
+      , cps = cps
+      , align = align
+      } in
+    (loader, method) in
+  let thinPeriod =
+    let default = 1 in
+    let opt = optArg
+      { optArgDefInt with long = "thin-period"
+      , description = concat "Keep every Nth sample produced. Default" (int2string default)
+      } in
+    optOr opt (optPure default) in
+  let incrementalPrinting = optFlag
+    { optFlagDef with long = "incremental-printing"
+    , description = "Print each sample as it is produced instead of at the end."
+    } in
+  let res = optApply (optApply (optApply (optMap5 mk thinPeriod incrementalPrinting _particles _mcmcLightweightGlobalProb _driftKernel) _driftScale) _cps) _align in
+  optMap2 (lam. lam x. x) (_methodFlag false "mcmc-lightweight") res in
+
+let wrapSimpleInferenceMethod
+  : OptParser InferMethod -> OptParser (Type -> Loader -> (Loader, InferMethod))
+  = optMap (lam m. lam. lam loader. (loader, m)) in
+
+let options : OptParser (TpplFrontendOptions, TransformationOptions, Type -> Loader -> (Loader, InferMethod)) =
+  let inference = foldl1 optOr
+    [ mcmcLightweightOptions
+    , wrapSimpleInferenceMethod isLwOptions
+    , wrapSimpleInferenceMethod smcApfOptions
+    , wrapSimpleInferenceMethod smcBpfOptions
+    , wrapSimpleInferenceMethod mcmcNaiveOptions
+    , wrapSimpleInferenceMethod mcmcTraceOptions
+    , wrapSimpleInferenceMethod pmcmcPimhOptions
+    ] in
+  optMap3 (lam a. lam b. lam c. (a, b, c)) tpplFrontendOptions transformationOptions inference in
+
+match optParseWithHelp "tpplc" "" options (tail argv)
+  with (frontend, transformations, mkInferenceMethod) in
+compileTpplToExecutable frontend transformations mkInferenceMethod

--- a/src/tpplc.mc
+++ b/src/tpplc.mc
@@ -25,22 +25,22 @@ mexpr
 use TreePPLThings in
 
 let mcmcLightweightOptions : OptParser (Type -> Loader -> (Loader, InferMethod)) =
-  let mk = lam thinPeriod. lam incrementalPrinting. lam iterations. lam globalProb. lam driftKernel. lam driftScale. lam cps. lam align. lam outputType. lam loader.
+  let mk = lam samplingPeriod. lam incrementalPrinting. lam iterations. lam globalProb. lam driftKernel. lam driftScale. lam cps. lam align. lam outputType. lam loader.
     match includeFileExn "." "stdlib::json.mc" loader with (jsonEnv, loader) in
     match serializationPairsFor [outputType] loader with (loader, [outputSer]) in
     let keepSample = if incrementalPrinting
       then ulam_ "" false_
-      else if eqi 1 thinPeriod
+      else if eqi 1 samplingPeriod
         then ulam_ "" true_
-        else ulam_ "idx" (eqi_ (int_ 0) (modi_ (var_ "idx") (int_ thinPeriod))) in
+        else ulam_ "idx" (eqi_ (int_ 0) (modi_ (var_ "idx") (int_ samplingPeriod))) in
     let continue =
       let ret = utuple_ [addi_ (var_ "idx") (int_ 1), neqi_ (var_ "idx") (int_ iterations)] in
       let ret =
         if incrementalPrinting then
           let print = app_ (nvar_ (_getVarExn "printJsonLn" jsonEnv)) (app_ outputSer.serializer (var_ "sample")) in
-          let print = if eqi thinPeriod 1
+          let print = if eqi samplingPeriod 1
             then print
-            else if_ (eqi_ (int_ 0) (modi_ (var_ "idx") (int_ thinPeriod))) print unit_ in
+            else if_ (eqi_ (int_ 0) (modi_ (var_ "idx") (int_ samplingPeriod))) print unit_ in
           semi_ print ret
         else ret in
       utuple_ [int_ 0, ulam_ "idx" (ulam_ "sample" ret)] in
@@ -54,18 +54,19 @@ let mcmcLightweightOptions : OptParser (Type -> Loader -> (Loader, InferMethod))
       , align = align
       } in
     (loader, method) in
-  let thinPeriod =
+  let samplingPeriod =
     let default = 1 in
     let opt = optArg
-      { optArgDefInt with long = "thin-period"
-      , description = concat "Keep every Nth sample produced. Default" (int2string default)
+      { optArgDefInt with long = "sampling-period"
+      , description = concat "Sample the mcmc-chain every Nth iteration. Default: " (int2string default)
+      , arg = "N"
       } in
     optOr opt (optPure default) in
   let incrementalPrinting = optFlag
     { optFlagDef with long = "incremental-printing"
     , description = "Print each sample as it is produced instead of at the end."
     } in
-  let res = optApply (optApply (optApply (optMap5 mk thinPeriod incrementalPrinting _particles _mcmcLightweightGlobalProb _driftKernel) _driftScale) _cps) _align in
+  let res = optApply (optApply (optApply (optMap5 mk samplingPeriod incrementalPrinting _particles _mcmcLightweightGlobalProb _driftKernel) _driftScale) _cps) _align in
   optMap2 (lam. lam x. x) (_methodFlag false "mcmc-lightweight") res in
 
 let wrapSimpleInferenceMethod

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -221,7 +221,7 @@ prod Constructor: ExprTppl =
 
 /----- Statements -----/
 prod ExprStmtTppl: StmtTppl = e:ExprTppl ";" -- Epxressions as statements
-prod Assume: StmtTppl = "assume" randomVar:LName (":" ty:TypeTppl)? "~" dist:ExprTppl ";"
+prod Assume: StmtTppl = "assume" randomVar:LName (":" ty:TypeTppl)? "~" dist:ExprTppl ("drift" driftKernel:ExprTppl)? ";"
 prod Assign: StmtTppl = "let" var:LName (":" ty:TypeTppl)? "=" val:ExprTppl ";"
 --prod Observe: StmtTppl = "observe" value:ExprTppl "~" distribution:UName "(" (args:ExprTppl ("," args:ExprTppl)*)? ")"
 prod Observe: StmtTppl = "observe" value:ExprTppl "~" dist:ExprTppl ";"


### PR DESCRIPTION
This PR implements and resolves #80, as well as updates the command line flags to use the new structure in miking-dppl. The latter also enables two new flags for `mcmc-lightweight`:

- `--thin-period N`, which keeps only every Nth sample produced by the mcmc chain.
- `--incremental-printing`, which prints each sample as it is produced. For the moment this means the program will print an empty distribution at the end of execution, which might not be desirable in the future.