### PR TITLE
Uncurried functions

### DIFF
--- a/models/lang/anonymous.tppl
+++ b/models/lang/anonymous.tppl
@@ -1,6 +1,7 @@
-model function example():() {
+model function example() => Int {
   let c = 10;
-  let x = sapply(1 to 5, function (i: Int) {
-    return addi(c, i);
+  let x = sapply(1 to 5, function (i: Int) => Int {
+    return c + i;
   });
+  return x[1];
 }

--- a/models/lang/blub.tppl
+++ b/models/lang/blub.tppl
@@ -17,7 +17,7 @@
  * Returns: nothing
  * Side-effect: prints things
  */
-model function blub(n: Int, pi: Real, trump: Bool, coinflips: Bool[], text: String) : () {
+model function blub(n: Int, pi: Real, trump: Bool, coinflips: Bool[], text: String) => () {
   printLn(text);
   print(text);
 

--- a/models/lang/coin.tppl
+++ b/models/lang/coin.tppl
@@ -28,7 +28,7 @@ function flip(datapoint: Bool, probability: Real) {
  * Posterior:
  *   p | coinflips
  */
-model function coinModel(coinflips: Bool[]) : Real  {
+model function coinModel(coinflips: Bool[]) => Real  {
   // Uncomment if you want to test the input
   //printLn("Input:");
   //let coinStr = apply(bool2string, coinflips);

--- a/models/lang/distributions.tppl
+++ b/models/lang/distributions.tppl
@@ -60,7 +60,7 @@ type TestDistributions = TestDistributions {
 }
 
 
-model function distributions() : TestDistributions {
+model function distributions() => TestDistributions {
 
   // Uniform
   assume aU ~ Uniform(0., 1.0);

--- a/models/lang/externals.tppl
+++ b/models/lang/externals.tppl
@@ -1,4 +1,4 @@
-model function coinModel(coinflips: Bool[]) : Real  {
+model function coinModel(coinflips: Bool[]) => Real  {
     let p = log(2.0);
     return p;
 }

--- a/models/lang/hello.tppl
+++ b/models/lang/hello.tppl
@@ -12,6 +12,6 @@
  * Returns: nothing
  * Side-effect: prints "Hello, world!"
  */
-model function hello() : () { 
+model function hello() => () { 
   printLn("Hello, world!");
 }

--- a/models/lang/matrix-tests.tppl
+++ b/models/lang/matrix-tests.tppl
@@ -6,23 +6,23 @@ type TestType = TestType {
 }
 
 
-model function tensors(): () {
-  dump(1);
+model function tensors() => () {
+  debug(1);
   let m2 = mtxCreateId(5);
-  dump(2);
+  debug(2);
   let x = [1.0, 2.0, 3.0, 4.0, 5.0];
-  dump(3);
+  debug(3);
   let y = rvecCreate(5, x); // Creates a row vector 1 x 5
-  dump(4);
+  debug(4);
   let m2xY = y *@ m2; // (1 x 5) x (5 x 5) --> 1 x 5
   printMtx(m2xY); /* we cannot return more than one tensor, so need to test by
                                                                     //printing */
 
   // Raising a matrix to an integer power -- P^n
-  dump(5);
+  debug(5);
   let m = mtxCreate(2, 2, [3.0, 0.0, -1.0, 7.0]);
-  dump(6);
-  let m4 = m ^$ 4;
+  debug(6);
+  let m4 = mtxPow(m, 4);
   printMtx(m4);
 
   // Adding two matrices

--- a/models/lang/mini-mat-test.tppl
+++ b/models/lang/mini-mat-test.tppl
@@ -1,3 +1,3 @@
-model function main(): () {
+model function main() => () {
   let m = mtxCreateId(5);
 }

--- a/models/lang/poly.tppl
+++ b/models/lang/poly.tppl
@@ -1,28 +1,28 @@
-function calculatePolynomial(index: Int, coeff: Real[], x: Real):Real {
+function calculatePolynomial(index: Int, coeff: Real[], x: Real) => Real {
     // TODO: Fix needing to cast index
-    if (int2real(index) >= int2real(length(coeff))) {
+    if (Real(index) >= Real(length(coeff))) {
         return 0.0;
     } else {
         //NOTE: Ambiguity errors recurse
-        //return coeff[index + 1] * x^n + calculatePolynomial(addi(index, 1), coeff, x);
+        //return coeff[index + 1] * x^n + calculatePolynomial(index + 1, coeff, x);
         //TODO: Fix needing to cast index
-        //return ( coeff[addi(index, 1)] * ( x^int2real(index)) ) + calculatePolynomial(addi(index, 1), coeff, x);
-        return ( coeff[addi(index, 1)] * ( x^ ( int2real(index) ) ) ) + calculatePolynomial(addi(index, 1), coeff, x);
+        //return ( coeff[index + 1] * ( x^Real(index)) ) + calculatePolynomial(index + 1, coeff, x);
+        return ( coeff[index + 1] * ( x^ ( Real(index) ) ) ) + calculatePolynomial(index + 1, coeff, x);
     }
 }
 
-function polynomialFunction(coeff: Real[], x: Real):Real {
+function polynomialFunction(coeff: Real[], x: Real) => Real {
     return calculatePolynomial(0, coeff, x);
 }
 
 
 
-model function poly(data: Real[][]): Int {
+model function poly(data: Real[][]) => Int {
     assume n ~ Poisson(1.0); // sample the degree of the polynomial
     let sigma = 1.0; // noise term
 
     // Sample the coefficients from n + 1 (we need one coeff for const poly)
-    let coeffs = repApply(addi(n, 1), function() {
+    let coeffs = repApply(n + 1, function(i : Int) => Real {
         assume g ~ Gaussian(0.0, 1.0);
         return g;
     });
@@ -32,6 +32,6 @@ model function poly(data: Real[][]): Int {
         let predictedY = polynomialFunction(coeffs, datum[1]);
         observe datum[2] ~ Gaussian(predictedY, sigma);
     });
-    
+
     return n;
 }

--- a/models/lang/ser-list.tppl
+++ b/models/lang/ser-list.tppl
@@ -1,4 +1,4 @@
-model function distributions() : Real[][] {
+model function distributions() => Real[][] {
   let dirAlphas = [2.0, 3.0, 5.0];
 
   let myDirP = DirichletParam {alphas = dirAlphas};

--- a/models/lang/tensors.tppl
+++ b/models/lang/tensors.tppl
@@ -29,7 +29,7 @@ type TensorRecord = TensorRecord {
  * but for linear algebra (matrix algebra) we use real tensors.
  *
  */
-model function tensors(magic: Int[]): TensorRecord {
+model function tensors(magic: Int[]) => TensorRecord {
   // Convert a sequence of integers to a sequence of reals
   let magicRealSequence = sapply(magic, int2real);
 
@@ -100,9 +100,6 @@ model function tensors(magic: Int[]): TensorRecord {
   let m = mtxCreate(2, 2, [3.14, 3.14, 2.78, 2.78]);
   let m4 = mtxPow(m, 4);
   printMtx(m4);
-
-  // we can also use a syntax     ^$ -- matrix to integer ppower
-  printMtx( m ^$ 4 );
 
   // Matrix addition
   // we have no matrix addition right now

--- a/models/metabarcoding/optmodel.tppl
+++ b/models/metabarcoding/optmodel.tppl
@@ -16,7 +16,7 @@
  * Posterior:
  *   returning k at the moment
  */
-model function myModel(dataset: Real[][]) : Real  {
+model function myModel(dataset: Real[][]) => Real  {
   assume k ~ Gamma(1.0, 10.0);
   assume logTheta ~ Gaussian(0.0, 2.0); 
   let theta = exp(logTheta);

--- a/models/pheno-mol/qt.tppl
+++ b/models/pheno-mol/qt.tppl
@@ -27,7 +27,7 @@ type QTTree =
                     , partialLogWeight: Real
                     }
 
-function tree2string(tree: QTTree): String {
+function tree2string(tree: QTTree) => String {
   if (tree is QTLeaf) {
     return paste0(["QTLeaf(", int2string(tree.index), ")"]);
   }
@@ -44,7 +44,7 @@ function tree2string(tree: QTTree): String {
   return "Error (tree2string): unexpected tree structure";
 }
 
-function gammaZeroMix(rho: Bool, a: Real, b: Real): Real {
+function gammaZeroMix(rho: Bool, a: Real, b: Real) => Real {
   if (rho) {
     assume x ~ Gamma(a, b);
     return x;
@@ -106,7 +106,7 @@ model function qtbirds( tree: QTTree
                       , nuScale: Real
                       , pa: Real
                       , pb: Real
-                      ): Real[]
+                      ) => Real[]
 {
   // printMtx(normQChar);
   // printMtx(jChar);
@@ -161,7 +161,7 @@ model function qtbirds( tree: QTTree
  *
  * @return QTTree that matches the QTWeightedLeaf constructor
  */
-function coalesceQTTree(tree: QTTree, m: ModelDynamics, doresample: Bool) : QTTree {
+function coalesceQTTree(tree: QTTree, m: ModelDynamics, doresample: Bool) => QTTree {
   if (tree.left is QTLeaf) && (tree.right is QTLeaf) {
     let newTree = QTWeightedNode  { left = tree.left
                                   , right = tree.right
@@ -215,7 +215,7 @@ function coalesceQTTree(tree: QTTree, m: ModelDynamics, doresample: Bool) : QTTr
  * coalesceQTTwig deals with a subtree that has two leafs as children
  * (they can be weighted or unweighted)
  */
-function coalesceQTTwig(tree: QTTree, m: ModelDynamics, doresample: Bool): QTTree {
+function coalesceQTTwig(tree: QTTree, m: ModelDynamics, doresample: Bool) => QTTree {
   let leftTime = getAgeDiff(tree, tree.left);
   let rightTime = getAgeDiff(tree, tree.right);
 
@@ -297,7 +297,7 @@ function coalesceQTTwig(tree: QTTree, m: ModelDynamics, doresample: Bool): QTTre
 }
 
 
-function getMessageSequence(tree: QTTree): Matrix[Real][] {
+function getMessageSequence(tree: QTTree) => Matrix[Real][] {
   if (tree is QTLeaf) {
     return sapply(tree.stateSequence, getMessage);
   }
@@ -316,12 +316,12 @@ function getMessageSequence(tree: QTTree): Matrix[Real][] {
 }
 
 // TODO/ WIP: What if the state is missing??
-function getMessage(state: Int): Matrix[Real] {
+function getMessage(state: Int) => Matrix[Real] {
   /* NOTE(vsenderov, 2023-11-01)
      - Messages hard-coded for now
      - see https://github.com/treeppl/treeppl/issues/30
   */
-  if (eqi(state, subi(0, 1))) {
+  if (state == 0 - 1) {
     return rvecCreate(4, [-1., -1., -1., -1.]);  // for now this is how we encode missing data
   }
 
@@ -330,17 +330,17 @@ function getMessage(state: Int): Matrix[Real] {
                   [0., 0., 1., 0.],    // 2
                   [0., 0., 0., 1.]];   // 3
 
-  return rvecCreate(4, messages[addi(state, 1)]); // one-indexing of arrays, but zero-indexing of states
+  return rvecCreate(4, messages[state + 1]); // one-indexing of arrays, but zero-indexing of states
 }
 
 
-function getCharacterMessage(tree: QTTree, messages: Real[][]): Matrix[Real]
+function getCharacterMessage(tree: QTTree, messages: Real[][]) => Matrix[Real]
 {
   if (tree is QTLeaf)
   {
     let l = length(messages);
     let curState = idInt(tree.characterState); // workaround
-    let rTensor = rvecCreate(l, messages[addi(1, curState)]);
+    let rTensor = rvecCreate(l, messages[1 + curState]);
     return rTensor;
   }
 
@@ -362,13 +362,13 @@ type MessageEvolution = MessageEvolution  { message: Matrix[Real]
                                           }
 
 // workaround not elegant, otherwise name clash
-function meGetMessage (mes: MessageEvolution): Matrix[Real]
+function meGetMessage(mes: MessageEvolution) => Matrix[Real]
 {
   return mes.message;
 }
 
 // workaround not elegant
-function meGetJumps (mes: MessageEvolution): Int
+function meGetJumps(mes: MessageEvolution) => Int
 {
   return mes.sJumps;
 }
@@ -383,11 +383,11 @@ function meGetJumps (mes: MessageEvolution): Int
 *   The initial likelihood as a row vector
 *   If the mes has negative values, it is considered missing data
 */
-function evolveMessageClosure ( dyn: ModelDynamics
+function evolveMessageClosure( dyn: ModelDynamics
                               , t: Real
                               , u: Real
                               , mes: Matrix[Real]
-                              ): MessageEvolution
+                              ) => MessageEvolution
 {
   assume sJumps ~ Poisson(dyn.nu * t * u); // divided by number of nucleotides
   // Missing data case
@@ -398,7 +398,7 @@ function evolveMessageClosure ( dyn: ModelDynamics
       sJumps = sJumps
     };
   }
-  let res = mes *@ ( ( dyn.jMol ^$ sJumps ) *@ (mtxExp(dyn.qMol *$ t)));
+  let res = mes *@ ( mtxPow(dyn.jMol, sJumps) *@ (mtxExp(dyn.qMol *$ t)));
   // TODO do something for operator precedence to avoid so many parens
   return MessageEvolution {
     message = res,
@@ -407,10 +407,10 @@ function evolveMessageClosure ( dyn: ModelDynamics
 }
 
 
-function evolveCharacter(mes: Matrix[Real], m: ModelDynamics, t: Real, sJumps: Int): Matrix[Real]
+function evolveCharacter(mes: Matrix[Real], m: ModelDynamics, t: Real, sJumps: Int) => Matrix[Real]
 {
   // TODO on top of that we need to add the s-jumps
-  let res = mes *@ ( (m.jChar ^$ sJumps) *@ (mtxExp(m.qChar *$ t)) );
+  let res = mes *@ (mtxPow(m.jChar, sJumps) *@ mtxExp(m.qChar *$ t) );
   return res;
 }
 
@@ -427,10 +427,10 @@ type MessageSequenceEvolution = MessageSequenceEvolution {
 function evolveMessageSequence( messages: Matrix[Real][]
                               , m: ModelDynamics
                               , t: Real
-                              ) : MessageSequenceEvolution
+                              ) => MessageSequenceEvolution
 {
   let u = 1.0/Real(length(messages));
-  let evolveMessage = evolveMessageClosure(m, t, u); // partial application
+  let evolveMessage = function(x : Matrix[Real]) => MessageEvolution {return evolveMessageClosure(m, t, u, x);}; // partial application
   let ret = sapply(messages, evolveMessage);
 
   return MessageSequenceEvolution {
@@ -445,7 +445,7 @@ function evolveMessageSequence( messages: Matrix[Real][]
  * into.  Makes the necesseity for writing tests even more apparent.
  *
 */
-function computeMessageLogLikelihood(mes: Matrix[Real]): Real
+function computeMessageLogLikelihood(mes: Matrix[Real]) => Real
 {
   if (isMissing(mes)) {
     return 0.;
@@ -469,34 +469,34 @@ function computeMessageLogLikelihood(mes: Matrix[Real]): Real
 //  ╚══╝╚══╝  ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝  ╚═════╝ ╚═╝  ╚═══╝╚═════╝ ╚══════╝
 //https://patorjk.com/software/taag/#p=testall&h=1&v=1&f=Univers&t=WORKAROUNDS
 
-function getAgeDiff(parent: QTTree, child: QTTree)
+function getAgeDiff(parent: QTTree, child: QTTree) => Real
 {
   return parent.age - child.age;
 }
 
 
-function idTensorReal(t: Matrix[Real])
+function idTensorReal(t: Matrix[Real]) => Matrix[Real]
 {
   return t;
 }
 
 
-function idSTensorReal(t: Matrix[Real][])
+function idSTensorReal(t: Matrix[Real][]) => Matrix[Real][]
 {
   return t;
 }
 
 
-function idSeq(s: Real[]) {
+function idSeq(s: Real[]) => Real[] {
   return s;
 }
 
 
-function idInt(i: Int) {
+function idInt(i: Int) => Int {
   return i;
 }
 
-function getIndex(tree: QTTree): Int
+function getIndex(tree: QTTree) => Int
 {
   if (tree is QTLeaf)
   {
@@ -511,7 +511,7 @@ function getIndex(tree: QTTree): Int
  * Multiplies two tensors, ignores if missing data is encoded as -1.
  * Hack!
  */
-function mtxElemMulMissing(a: Matrix[Real], b: Matrix[Real]): Matrix[Real] {
+function mtxElemMulMissing(a: Matrix[Real], b: Matrix[Real]) => Matrix[Real] {
   if (isMissing(a)) {
     if (isMissing(b)) {
       return a; // doesn't matter which one we return, both are missing
@@ -527,7 +527,7 @@ function mtxElemMulMissing(a: Matrix[Real], b: Matrix[Real]): Matrix[Real] {
   return mtxElemMul(a, b);
 }
 
-function isMissing(x: Matrix[Real]): Bool {
+function isMissing(x: Matrix[Real]) => Bool {
   if (mtxGet(1, 1, x) < 0.) {
     return true;
   }

--- a/models/phylogeny/clads.tppl
+++ b/models/phylogeny/clads.tppl
@@ -10,26 +10,26 @@ type SpecTree =
   | Node {left : SpecTree, right : SpecTree, age : Real}
   | Leaf {age : Real}
 
-function new_rate(g: Globals, logSplitRate: Real): Real {
+function new_rate(g: Globals, logSplitRate: Real) => Real {
   assume newRate ~ Gaussian(logSplitRate, g.rateVariance);
   return g.logActivity + newRate;
 }
 
-function min(a: Real, b: Real): Real {
+function min(a: Real, b: Real) => Real {
   if a <= b {
     return a;
   }
   return b;
 }
 
-function max(a: Real, b: Real): Real {
+function max(a: Real, b: Real) => Real {
   if a <= b {
     return b;
   }
   return a;
 }
 
-function survives(g: Globals, age: Real, logSplitRate: Real): Bool {
+function survives(g: Globals, age: Real, logSplitRate: Real) => Bool {
   if log(100000.0) <= logSplitRate - g.logInitSplitRate {
     // We have a really high splitrate, which makes us blow the stack,
     // so abort this execution, assuming we'll survive
@@ -61,7 +61,7 @@ function survives(g: Globals, age: Real, logSplitRate: Real): Bool {
   return false;
 }
 
-function observeExtinct(g: Globals, age: Real, logSplitRate: Real): Bool {
+function observeExtinct(g: Globals, age: Real, logSplitRate: Real) => Bool {
   if survives(g, age, logSplitRate) {
     // We survived, but we wanted to be extinct
     weight 0.0;
@@ -135,21 +135,21 @@ function observeTree(g: Globals, age: Real, logSplitRate: Real, tree: SpecTree) 
   }
 }
 
-function countLeaves(tree: SpecTree): Real {
+function countLeaves(tree: SpecTree) => Real {
   if tree is Node {
     return 1.0 + countLeaves(tree.left) + countLeaves(tree.right);
   }
   return 1.0;
 }
 
-function logFactorial(n: Real): Real {
+function logFactorial(n: Real) => Real {
   if n <= 0.0 {
     return 0.0;
   }
   return log(n) + logFactorial(n - 1.0);
 }
 
-model function top(tree: SpecTree, rho: Real): Real {
+model function top(tree: SpecTree, rho: Real) => Real {
   assume lambda ~ Gamma(1.0, 1.0);
   assume mu ~ Gamma(1.0, 0.5);
   assume sigma ~ Gamma(1.0, 1.0);

--- a/models/phylogeny/crbd.tppl
+++ b/models/phylogeny/crbd.tppl
@@ -2,21 +2,21 @@ type Tree =
   | Node {left: Tree, right: Tree, age: Real}
   | Leaf {age: Real}
 
-function countLeaves(tree: Tree): Real {
+function countLeaves(tree: Tree) => Real {
   if tree is Node {
     return countLeaves(tree.left) + countLeaves(tree.right);
   }
   return 1.0;
 }
 
-function logFactorial(n: Real): Real {
+function logFactorial(n: Real) => Real {
   if n <= 1.0 {
     return 0.0;
   }
   return log(n) + logFactorial(n - 1.0);
 }
 
-function simulateSubtree(time: Real, lambda: Real, mu: Real, rho: Real): Bool {
+function simulateSubtree(time: Real, lambda: Real, mu: Real, rho: Real) => Bool {
   assume waitingTime ~ Exponential(lambda + mu);
   if waitingTime > time {
     assume undetected ~ Bernoulli(1.0 - rho);
@@ -32,7 +32,7 @@ function simulateSubtree(time: Real, lambda: Real, mu: Real, rho: Real): Bool {
   return true;
 }
 
-function walk(node: Tree, time:Real, lambda: Real, mu: Real, rho: Real): Bool {
+function walk(node: Tree, time:Real, lambda: Real, mu: Real, rho: Real) => Bool {
   assume waitingTime ~ Exponential(lambda);
   if time - waitingTime > node.age {
     if simulateSubtree(time - waitingTime, lambda, mu, rho) {
@@ -58,7 +58,7 @@ function walk(node: Tree, time:Real, lambda: Real, mu: Real, rho: Real): Bool {
   return true;
 }
 
-model function crbd(tree: Tree, rho: Real): Real {
+model function crbd(tree: Tree, rho: Real) => Real {
   assume lambda ~ Gamma(1.0, 1.0);
   assume mu ~ Gamma(1.0, 0.5);
   let leaves = countLeaves(tree);

--- a/models/phylogeny/host_repertoire.tppl
+++ b/models/phylogeny/host_repertoire.tppl
@@ -80,7 +80,7 @@ type ReturnType = ReturnType{tree: HistoryTree, lambda: Real[], mu: Real, beta: 
  */
 
 model function mymodel(symbiont_tree: TreeLabeled, ntips: Int, nhosts: Int, interactions: Int[],
-  host_distances: Real[], dMean: Real, tune: Real): ReturnType {
+  host_distances: Real[], dMean: Real, tune: Real) => ReturnType {
 
   // Set priors for model parameters
   assume lambda ~ Dirichlet([1.0,1.0,1.0,1.0]);
@@ -170,7 +170,7 @@ model function mymodel(symbiont_tree: TreeLabeled, ntips: Int, nhosts: Int, inte
  *   probabilities for all nodes in the symbiont tree.
  */
 function get_proposal_params(symbiont_tree: TreeLabeled, iMatrix: Matrix[Real], qMatrix: Matrix[Real],
-  stationary_probs: Matrix[Real], tune: Real): ProbsTree {
+  stationary_probs: Matrix[Real], tune: Real) => ProbsTree {
 
   let msgTree = postorder_msgs(symbiont_tree, iMatrix, qMatrix);
   let n = length(getMsgTreeMsg(msgTree));
@@ -180,7 +180,7 @@ function get_proposal_params(symbiont_tree: TreeLabeled, iMatrix: Matrix[Real], 
 }
 
 // Compute postorder messages on the observed tree
-function postorder_msgs(tree: TreeLabeled, iMatrix: Matrix[Real], qMatrix: Matrix[Real]) : MsgTree {
+function postorder_msgs(tree: TreeLabeled, iMatrix: Matrix[Real], qMatrix: Matrix[Real]) => MsgTree {
 
   if tree is Leaf {
     return MsgLeaf{age = 0.0, label = tree.label, out_msg = observationMessage(mtxGetRow(tree.label, iMatrix))};
@@ -203,13 +203,13 @@ function postorder_msgs(tree: TreeLabeled, iMatrix: Matrix[Real], qMatrix: Matri
 }
 
 // Compute leaf message from observed interactions
-function observationMessage(obs_repertoire: Matrix[Real]) : Matrix[Real][] {
+function observationMessage(obs_repertoire: Matrix[Real]) => Matrix[Real][] {
   return tapply(obs_repertoire, makeStateMessage);
 }
 
 // Takes a single interaction and creates the message
 // Interactions are of type Real because of limitations in boolean comparisons
-function makeStateMessage(interaction: Real): Matrix[Real] {
+function makeStateMessage(interaction: Real) => Matrix[Real] {
   // NOTE: we do not have a switch statement, perhaps we need in the future?
 
   if (interaction == 0.0) {
@@ -228,7 +228,7 @@ function makeStateMessage(interaction: Real): Matrix[Real] {
 }
 
 // Compute final probabilities from belief propagation on the observed symbiont tree
-function final_probs(tree: MsgTree, parent_msg: Matrix[Real][], qMatrix: Matrix[Real], tune: Real) : ProbsTree {
+function final_probs(tree: MsgTree, parent_msg: Matrix[Real][], qMatrix: Matrix[Real], tune: Real) => ProbsTree {
 
   let probs = messageNormalize(
 		messageElemPow(messageElemMul(tree.out_msg, parent_msg), tune)
@@ -257,7 +257,7 @@ function final_probs(tree: MsgTree, parent_msg: Matrix[Real][], qMatrix: Matrix[
 /*---------------- Model functions -------------------------*/
 
 // Simulate an evolutionary history for the host repertoires, from root to leaves
-function simulate (tree: ProbsTree, start: HistoryPoint, mp: ModelParams, iMatrix: Matrix[Real]) : HistoryTree {
+function simulate (tree: ProbsTree, start: HistoryPoint, mp: ModelParams, iMatrix: Matrix[Real]) => HistoryTree {
 
   // Propose a repertoire. The propose mechanism means that the simulation
   // should be "penalized" for the probability associated with the draw.
@@ -301,7 +301,7 @@ function simulate (tree: ProbsTree, start: HistoryPoint, mp: ModelParams, iMatri
 // Simulate history conditional on initial repertoire, start time, and end
 // time. We first propose events from the independence model and then
 // condition the simulation on those events.
-function simulate_history (from_rep: HistoryPoint, to_rep: HistoryPoint, mp: ModelParams) : HistoryPoint[] {
+function simulate_history (from_rep: HistoryPoint, to_rep: HistoryPoint, mp: ModelParams) => HistoryPoint[] {
 
   let proposed_unordered_events = propose_events(1, from_rep, to_rep, mp.qMatrix);
   // order events by decreasing age
@@ -317,16 +317,16 @@ function simulate_history (from_rep: HistoryPoint, to_rep: HistoryPoint, mp: Mod
 }
 
 // Propose events from independence model
-function propose_events (host_index: Int, from_rep: HistoryPoint, to_rep: HistoryPoint, qMatrix: Matrix[Real]) : ProposedHistory {
+function propose_events (host_index: Int, from_rep: HistoryPoint, to_rep: HistoryPoint, qMatrix: Matrix[Real]) => ProposedHistory {
 
   // End case, have already done all hosts ins the repertoire
-  if (gti(host_index, length(from_rep.repertoire))) {
+  if (host_index > length(from_rep.repertoire)) {
 		return ProposedHistory{log_debt = 0.0, events = []};
 	}
   let propHist1 = propose_events_for_host(host_index, from_rep.age, to_rep.age,
 		from_rep.repertoire[host_index], to_rep.repertoire[host_index], qMatrix);
 
-  let propHist2 = propose_events(addi(host_index, 1), from_rep, to_rep, qMatrix);
+  let propHist2 = propose_events(host_index + 1, from_rep, to_rep, qMatrix);
 
   return ProposedHistory{log_debt = propHist1.log_debt + propHist2.log_debt,
 												 events = concat(propHist1.events, propHist2.events)};
@@ -335,16 +335,16 @@ function propose_events (host_index: Int, from_rep: HistoryPoint, to_rep: Histor
 
 // Propose events for one host
 function propose_events_for_host (host_index: Int, from_age: Real, end_age: Real,
-	from_state: Int, end_state: Int, qMatrix: Matrix[Real]) : ProposedHistory {
+	from_state: Int, end_state: Int, qMatrix: Matrix[Real]) => ProposedHistory {
 
-	let rate = -(mtxGet(addi(from_state,1), addi(from_state,1), qMatrix));
+  let rate = -(mtxGet(from_state + 1, from_state + 1, qMatrix));
 
   // Kill the particle if we are trying to subdivide a time segment that
   // is too short. This will come with a big penalty in either case but
   // continuing to run the code will result in numerical problems like
   // sampling waiting times that are -0. and getting debts that are inf,
   // both of which are difficult to handle.
-  if (rate * (from_age - end_age) < 1E-15 && !eqi(from_state,end_state)) {
+  if (rate * (from_age - end_age) < 1E-15 && from_state != end_state) {
     weight 0.0;
     resample;
   }
@@ -363,11 +363,11 @@ function propose_events_for_host (host_index: Int, from_age: Real, end_age: Real
 
   let log_wait_debt = getLogWaitDebt(from_state, end_state, rate, from_age, end_age, t);
 	let to_states = getToStates(from_state);
-	let state_probs = seqNormalize([mtxGet(addi(from_state,1), addi(to_states[1],1), qMatrix),
-																	mtxGet(addi(from_state,1), addi(to_states[2],1), qMatrix)]);
+	let state_probs = seqNormalize([mtxGet(from_state + 1, to_states[1] + 1, qMatrix),
+																	mtxGet(from_state + 1, to_states[2] + 1, qMatrix)]);
 
 	assume new_state_pos ~ Categorical(state_probs);
-	let new_state = to_states[addi(new_state_pos, 1)];
+	let new_state = to_states[new_state_pos + 1];
   // Note: Categorical is 0-based, so we need to add 1 do get the correct position
 	let log_event_debt = categoricalLogScore(new_state_pos, CategoricalParam{probs = state_probs});
   // Note: Use position instead of value
@@ -379,16 +379,16 @@ function propose_events_for_host (host_index: Int, from_age: Real, end_age: Real
 
 }
 
-function getLogWaitDebt(from_state: Int, end_state: Int, rate: Real, from_age: Real, end_age: Real, t: Real): Real {
-	if (!eqi(from_state,end_state)) {
+function getLogWaitDebt(from_state: Int, end_state: Int, rate: Real, from_age: Real, end_age: Real, t: Real) => Real {
+	if (from_state != end_state) {
 		return log_pdf_exponential_max_t(t, rate, from_age - end_age);
 	} else {
 		return exponentialLogScore(t, ExponentialParam{rate = rate});
 	}
 }
 
-function getWaitingTime(from_state: Int, end_state: Int, rate: Real, from_age: Real, end_age: Real): Real {
-	if (!eqi(from_state,end_state)) {
+function getWaitingTime(from_state: Int, end_state: Int, rate: Real, from_age: Real, end_age: Real) => Real {
+	if (from_state != end_state) {
 		return sample_exponential_max_t(rate, from_age - end_age);
 	} else {
 		assume t ~ Exponential(rate);
@@ -396,7 +396,7 @@ function getWaitingTime(from_state: Int, end_state: Int, rate: Real, from_age: R
 	}
 }
 
-function getToStates(state: Int): Int[] {
+function getToStates(state: Int) => Int[] {
 	if (Real(state) == 0.0) {
 		return [1,2];
 	} else {
@@ -414,7 +414,7 @@ function getToStates(state: Int): Int[] {
 
 // Sample from truncated exponential distribution with rate 'rate'
 // but with support only on (0, max_t).
-function sample_exponential_max_t(rate: Real, max_t: Real) : Real {
+function sample_exponential_max_t(rate: Real, max_t: Real) => Real {
   let u_min = exp (-(rate * max_t));
   assume u ~ Uniform (u_min, 1.0);
   return ((-(log(u))) / rate);
@@ -422,7 +422,7 @@ function sample_exponential_max_t(rate: Real, max_t: Real) : Real {
 
 // Compute log PDF for a value from the truncated exponential
 // The truncation multiplies the pdf with 1/(1-u_min).
-function log_pdf_exponential_max_t(value : Real, rate: Real, max_t: Real) : Real {
+function log_pdf_exponential_max_t(value : Real, rate: Real, max_t: Real) => Real {
 	let u_min = exp(-(rate * max_t));
   return ( (-(rate * value * log(rate))) - log(1.0-u_min));
 }
@@ -432,10 +432,10 @@ function log_pdf_exponential_max_t(value : Real, rate: Real, max_t: Real) : Real
 // accumulate scores here rather than introducing observe
 // statements, as those observes would not be aligned.
 function simulate_by_event (repertoire: Int[], eventSeq: Event[], event_index: Int,
-	from_age: Real, end_age: Real, mp: ModelParams, log_debt: Real) : HistoryScore {
+	from_age: Real, end_age: Real, mp: ModelParams, log_debt: Real) => HistoryScore {
 
 	// End case, deal with last time segment
-	if gti(event_index, length(eventSeq)) {
+	if event_index > length(eventSeq) {
 		let change_rate = total_rate(repertoire, mp);
 		return HistoryScore{log_score = poissonLogScore(0,
       PoissonParam{rate = change_rate*(from_age-end_age)}), history = []};
@@ -460,14 +460,14 @@ function simulate_by_event (repertoire: Int[], eventSeq: Event[], event_index: I
   let new_repertoire = sapplyi1(repertoire, getNewState, the_event);
 	let hp = HistoryPoint{age = the_event.age, repertoire = new_repertoire};
   // Simulate next event
-	let simHist = simulate_by_event(new_repertoire, eventSeq, addi(event_index,1), the_event.age, end_age, mp, log_debt);
+	let simHist = simulate_by_event(new_repertoire, eventSeq, event_index + 1, the_event.age, end_age, mp, log_debt);
 
 	return HistoryScore{log_score = simHist.log_score + logScore, history = concat(simHist.history, [hp])};
 }
 
 // Update host states
-function getNewState(i: Int, state: Int, event: Event): Int {
-	if ( eqi(i, event.host) ) {
+function getNewState(i: Int, state: Int, event: Event) => Int {
+	if (i == event.host) {
 	  return event.to_state;
 	} else {
 	  return state;
@@ -475,16 +475,16 @@ function getNewState(i: Int, state: Int, event: Event): Int {
 }
 
 // Compute rate for a proposed event
-function getRate (repertoire: Int[], host_index: Int, to_state: Int, mp: ModelParams): Real {
+function getRate(repertoire: Int[], host_index: Int, to_state: Int, mp: ModelParams) => Real {
 
   let from_state = repertoire[host_index];
-  let base_rate = mtxGet(addi(from_state,1), addi(to_state,1), mp.qMatrix);
+  let base_rate = mtxGet(from_state + 1, to_state + 1, mp.qMatrix);
 
   // Losses are easy, no cross-repertoire modification used here
-  if (gti(from_state, to_state)) {
+  if (from_state > to_state) {
 
 		let n2s = fold(count2s, 0, repertoire);
-		if (eqi(from_state, 2) && Real(n2s) == 1.0) {
+		if (from_state == 2 && n2s == 1) {
 			return 0.0;
 		} else {
 			return base_rate;
@@ -492,7 +492,7 @@ function getRate (repertoire: Int[], host_index: Int, to_state: Int, mp: ModelPa
 	} else {
 
     // We have a gain rate, so we need to factor in beta-dependent cross-repertoire effect
-    if (eqi(from_state, 0)) {
+    if (from_state == 0) {
       let current_hosts = whichTrue(sapply(repertoire, is1or2));
       let dist = mtxMean(mtxRowCols(mp.dMatrix, host_index, current_hosts));
       return base_rate * (exp(-(mp.beta*(dist/mp.dMean))));
@@ -506,7 +506,7 @@ function getRate (repertoire: Int[], host_index: Int, to_state: Int, mp: ModelPa
 }
 
 // Compute total rate of change from a repertoire
-function total_rate (repertoire: Int[], mp: ModelParams): Real {
+function total_rate(repertoire: Int[], mp: ModelParams) => Real {
 
 	let n1s = fold(count1s, 0, repertoire);
 	let totalLoss1 = Real(n1s) * mtxGet(2, 1, mp.qMatrix);
@@ -519,7 +519,7 @@ function total_rate (repertoire: Int[], mp: ModelParams): Real {
   return totalLoss1 + totalLoss2 + totalGains;
 }
 
-function getLoss2 (n2s: Real, mp: ModelParams): Real {
+function getLoss2(n2s: Real, mp: ModelParams) => Real {
   if n2s <= 1.0 {
 		let totalLoss2 = 0.0;
     return totalLoss2;
@@ -529,10 +529,10 @@ function getLoss2 (n2s: Real, mp: ModelParams): Real {
 	}
 }
 
-function gainsIf0or1 (i: Int, from_state: Int, repertoire: Int[], mp: ModelParams): Real {
+function gainsIf0or1(i: Int, from_state: Int, repertoire: Int[], mp: ModelParams) => Real {
 
-	if (eqi(from_state, 0) || eqi(from_state, 1)) {
-		return getRate(repertoire, i, addi(from_state,1), mp);
+  if (from_state == 0 || from_state == 1) {
+    return getRate(repertoire, i, from_state + 1, mp);
 	} else {
 		return 0.0;
 	}
@@ -540,7 +540,7 @@ function gainsIf0or1 (i: Int, from_state: Int, repertoire: Int[], mp: ModelParam
 
 // Accumulate the total log debt of proposing the
 // ancestral repertoires in the tree.
-function get_rep_debt (tree: HistoryTree): Real {
+function get_rep_debt(tree: HistoryTree) => Real {
 
   if tree is HistoryLeaf {
 		return tree.log_rep_debt;
@@ -553,7 +553,7 @@ function get_rep_debt (tree: HistoryTree): Real {
 /*---------------- Help functions --------------------------*/
 
 
-function createProbRecord(p: Matrix[Real]): CategoricalParam {
+function createProbRecord(p: Matrix[Real]) => CategoricalParam {
   // This version works on tests, but not here
   // let ncol = dim(p)[2];
 	// let ps = rep(ncol, p);
@@ -567,71 +567,63 @@ function createProbRecord(p: Matrix[Real]): CategoricalParam {
   return CategoricalParam {probs = p_seq};
 }
 
-function getRowVecElem(t: Matrix[Real], i: Int): Real {
+function getRowVecElem(t: Matrix[Real], i: Int) => Real {
   return mtxGet(1, i, t);
 }
 
 // Calculate stationary probabilities from lambda values
-function stationaryProbs(lambda: Real[]): Matrix[Real] {
+function stationaryProbs(lambda: Real[]) => Matrix[Real] {
   let pi_1 = 1.0 / (1.0 + (lambda[2]/lambda[1]) + (lambda[3]/lambda[4]));
   let pi_0 = pi_1 * (lambda[2]/lambda[1]);
   let pi_2 = 1.0 - pi_0 - pi_1;
   return rvecCreate(3, [pi_0, pi_1, pi_2]);
 }
 
-function getMsgTreeAge(tree: MsgTree) : Real {
+function getMsgTreeAge(tree: MsgTree) => Real {
 	return tree.age;
 }
 
-function getMsgTreeMsg(tree: MsgTree) : Matrix[Real][] {
+function getMsgTreeMsg(tree: MsgTree) => Matrix[Real][] {
 	return tree.out_msg;
 }
 
-function getProbsTreeAge(tree: ProbsTree) : Real {
+function getProbsTreeAge(tree: ProbsTree) => Real {
 	return tree.age;
 }
 
-function getProbs(tree: ProbsTree): Matrix[Real][]{
+function getProbs(tree: ProbsTree) => Matrix[Real][]{
 	return tree.probs;
 }
 
-function subAge(left: Event, right: Event): Int {
-  let diff = subf(right.age, left.age);
+function subAge(left: Event, right: Event) => Int {
+  let diff = right.age - left.age;
   if (diff >= 0.0){
     return 1;
   } else {
-			return subi(1,2);  // type error if I just write -1
+    return 0 - 1;  // type error if I just write -1
 	}
 }
 
-function count2s(count: Int, host: Int): Int {
-	if (eqi(host, 2)) {
-		return addi(count, 1);
+function count2s(count: Int, host: Int) => Int {
+  if (host == 2) {
+    return count + 1;
 	} else {
-			return count;
+    return count;
 	}
 }
 
-function count1s(count: Int, host: Int): Int {
-	if (eqi(host, 1)) {
-		return addi(count, 1);
+function count1s(count: Int, host: Int) => Int {
+  if (host == 1) {
+    return count + 1;
 	} else {
-			return count;
+    return count;
 	}
 }
 
-function is2(x: Int): Bool {
-  if (eqi(x, 2)) {
-    return true;
-  } else {
-      return false;
-  }
+function is2(x: Int) => Bool {
+  return x == 2;
 }
 
-function is1or2(x: Int): Bool {
-  if (eqi(x,1) || eqi(x,2)) {
-    return true;
-  } else {
-			return false;
-	}
+function is1or2(x: Int) => Bool {
+  return x == 1 || x == 2;
 }

--- a/models/phylogeny/substmodel_belief_propagation.tppl
+++ b/models/phylogeny/substmodel_belief_propagation.tppl
@@ -34,7 +34,7 @@ type GTR_Tree =
 // MODEL FUNCTIONS
 
 // A help function to compute the scaled rate matrix for GTR
-function gtr(pi: Real[], r: Real[]) : Matrix[Real] {
+function gtr(pi: Real[], r: Real[]) => Matrix[Real] {
     // Construct a matrix of exchangeability rates
     let unscaled_q = mtxCreate(4,4,
                      [ -(pi[2]*r[1]+pi[3]*r[2]+pi[4]*r[3]),      pi[2]*r[1],                            pi[3]*r[2],                             pi[4]*r[3] ,
@@ -55,13 +55,13 @@ function gtr(pi: Real[], r: Real[]) : Matrix[Real] {
 // A simple help function to compute a message for a branch in the tree in a
 // postorder traversal towards the root. We assume standard conventions here
 // for the structure of q with respect to time (rows = from-states)
-function message(start_msg: Matrix[Real][], q: Matrix[Real], time: Real) : Matrix[Real][] {
+function message(start_msg: Matrix[Real][], q: Matrix[Real], time: Real) => Matrix[Real][] {
     let trans_matrix = mtxTrans(mtxExp(mtxSclrMul(time, q)));
     return sapply1(start_msg, mtxMul, trans_matrix);
 }
 
 // Compute postorder messages on the observed tree
-function compute_postorder_message(tree: GTR_Tree, data: Int[][], q: Matrix[Real]) : Matrix[Real][] {
+function compute_postorder_message(tree: GTR_Tree, data: Int[][], q: Matrix[Real]) => Matrix[Real][] {
     if (tree is Leaf) {
         return sapply(data[tree.index], get_leaf_message);
     }
@@ -74,24 +74,24 @@ function compute_postorder_message(tree: GTR_Tree, data: Int[][], q: Matrix[Real
 
 
 // Get message from leaves for each site
-function get_leaf_message(seq: Int) : Matrix[Real] {
-    if (eqi(seq, 0)) { // "A"
+function get_leaf_message(seq: Int) => Matrix[Real] {
+    if (seq == 0) { // "A"
        let message = rvecCreate(4, [1.0, 0.0, 0.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 1)) { // "C"
+    if (seq == 1) { // "C"
         let message = rvecCreate(4, [0.0, 1.0, 0.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 2)) { // "G"
+    if (seq == 2) { // "G"
         let message = rvecCreate(4, [0.0, 0.0, 1.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 3)) {  // "T"
+    if (seq == 3) {  // "T"
         let message = rvecCreate(4, [0.0, 0.0, 0.0, 1.0]);
         return message;
     }
-    if (eqi(seq, 4)) {  // "-" or "?"
+    if (seq == 4) {  // "-" or "?"
         let message = rvecCreate(4, [1.0, 1.0, 1.0, 1.0]);
         return message;
     }
@@ -101,7 +101,7 @@ function get_leaf_message(seq: Int) : Matrix[Real] {
 }
 
 //Compute log likelihood for each site
-function get_log_likes(msg: Matrix[Real], pi_col: Matrix[Real]): Real {
+function get_log_likes(msg: Matrix[Real], pi_col: Matrix[Real]) => Real {
     let like = mtxMul(msg, pi_col);
     let log_like = log(mtxGet(1, 1, like));
     return log_like;
@@ -109,7 +109,7 @@ function get_log_likes(msg: Matrix[Real], pi_col: Matrix[Real]): Real {
 
 // MODEL
 // clock_rate not needed in this version
-model function myModel(data: Int[][], tree: GTR_Tree) : TheReturn {
+model function myModel(data: Int[][], tree: GTR_Tree) => TheReturn {
 
     // Sample stationary probs and exchangeability rates and
     // compute the scaled rate matrix for the GTR model.

--- a/models/phylogeny/tree_inference.tppl
+++ b/models/phylogeny/tree_inference.tppl
@@ -29,41 +29,41 @@ type SeqTree =
 // FUNCTIONS
 
 // Build forest of trees from leaves, recursively
-function buildForest(data: Int[][], forest: SeqTree[], index: Int, dataLen: Int): SeqTree[]
+function buildForest(data: Int[][], forest: SeqTree[], index: Int, dataLen: Int) => SeqTree[]
 {
     let newLeaf = Leaf{age=0.0, seq=data[index]};
     let new_forest = paste0([forest, [newLeaf]]);
-    if (eqi(dataLen, index)) {
+    if (dataLen == index) {
         return new_forest;
     }
     else {
-        return buildForest(data, new_forest, addi(index, 1), dataLen);
+        return buildForest(data, new_forest, index + 1, dataLen);
     }
 }
 
 // Randomly sample two indices in the trees vector, to be combined. Avoiding mirror cases.
-function pickpair(n: Int): Int[] {
-    assume i_1 ~ Categorical(rep(subi(n, 1), 1./Real(subi(n, 1))));
-    let i = addi(i_1, 2); //Adding two, avoiding index zero for i and avoiding trouble picking j
-    assume j ~ Categorical(rep(subi(i, 1), 1./Real(subi(i, 1))));  // j is always smaller than i, avoiding mirror cases
-    return [i, addi(j, 1)]; //avoid index of zero for j
+function pickpair(n: Int) => Int[] {
+    assume i_1 ~ Categorical(rep(n - 1, 1./Real(n - 1)));
+    let i = i_1 + 2; //Adding two, avoiding index zero for i and avoiding trouble picking j
+    assume j ~ Categorical(rep(i - 1, 1./Real(i - 1)));  // j is always smaller than i, avoiding mirror cases
+    return [i, j + 1]; //avoid index of zero for j
 }
 
 //Note: this is not optimal, in terms of repeated calculation of matrix exp
-function ctmc(initialstate: Int, q: Matrix[Real], t: Real): Real[]
+function ctmc(initialstate: Int, q: Matrix[Real], t: Real) => Real[]
 {
     let choices = [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]];
-    let state = rvecCreate(4, choices[addi(initialstate, 1)]);
+    let state = rvecCreate(4, choices[initialstate + 1]);
     let p = state *@ (mtxExp(q *$ t));
     return[mtxGet(1, 1, p), mtxGet(1, 2, p), mtxGet(1, 3, p), mtxGet(1, 4, p)];
 }
 
-function cluster(q: Matrix[Real], trees: SeqTree[], maxAge: Real, seqLen: Int): SeqTree[]
+function cluster(q: Matrix[Real], trees: SeqTree[], maxAge: Real, seqLen: Int) => SeqTree[]
 {
     let n = length(trees);
 
     // Check if we have reached the root of the tree
-    if (eqi(n, 1)) {
+    if (n == 1) {
         return trees;
     }
     // Randomly sample two indices in the trees vector with function pickpair
@@ -99,7 +99,7 @@ function cluster(q: Matrix[Real], trees: SeqTree[], maxAge: Real, seqLen: Int): 
     // Compute new_trees list
     let min = pairs[2];
     let max = pairs[1];
-    let new_trees = paste0([slice(trees, 1, min), slice(trees, addi(min, 1), max), slice(trees, addi(max, 1), addi(n, 1)), [parent]]);
+    let new_trees = paste0([slice(trees, 1, min), slice(trees, min + 1, max), slice(trees, max + 1, n + 1), [parent]]);
 
     // Recursive call to cluster for new_trees
     return cluster(q, new_trees, age, seqLen);
@@ -107,7 +107,7 @@ function cluster(q: Matrix[Real], trees: SeqTree[], maxAge: Real, seqLen: Int): 
 
 // MODEL
 
-model function myModel(data: Int[][]) : SeqTree[]
+model function myModel(data: Int[][]) => SeqTree[]
 {
     // Define the scaled rate matrix for Jukes-Cantor
     let q = mtxCreate(4,4,

--- a/models/phylogeny/tree_inference_pruning.tppl
+++ b/models/phylogeny/tree_inference_pruning.tppl
@@ -28,45 +28,45 @@ type MsgTree =
 // FUNCTIONS
 
 // Randomly sample two indices in the trees vector, to be combined. Avoiding mirror cases.
-function pickpair(n: Int): Int[] {
-    assume i_1 ~ Categorical(rep(subi(n, 1), 1./Real(subi(n, 1))));
-    let i = addi(i_1, 2); //Adding two, avoiding index zero for i and avoiding trouble picking j
-    assume j ~ Categorical(rep(subi(i, 1), 1./Real(subi(i, 1))));  // j is always smaller than i, avoiding mirror cases
-    return [i, addi(j, 1)]; //avoid index of zero for j
+function pickpair(n: Int) => Int[] {
+    assume i_1 ~ Categorical(rep(n - 1, 1./Real(n - 1)));
+    let i = i_1 + 2; //Adding two, avoiding index zero for i and avoiding trouble picking j
+    assume j ~ Categorical(rep(i - 1, 1./Real(i - 1)));  // j is always smaller than i, avoiding mirror cases
+    return [i, j + 1]; //avoid index of zero for j
 }
 
 // Build forest of trees from leaves, recursively
-function build_forest(data: Int[][], forest: MsgTree[], index: Int, data_len: Int, seq_len: Int): MsgTree[] {
+function build_forest(data: Int[][], forest: MsgTree[], index: Int, data_len: Int, seq_len: Int) => MsgTree[] {
     let new_message = sapply(data[index], get_leaf_message);
     let new_leaf = Leaf{age = 0.0, index = index, msg =  new_message};
     let new_forest = paste0([forest, [new_leaf]]);
-    if (eqi(data_len, index)) {
+    if (data_len == index) {
         return new_forest;
     }
     else {
-        return build_forest(data, new_forest, addi(index, 1), data_len, seq_len);
+        return build_forest(data, new_forest, index + 1, data_len, seq_len);
     }
 }
 
 // Get message from leaves for each site
-function get_leaf_message(seq: Int) : Matrix[Real] {
-    if (eqi(seq, 0)) { // "A"
+function get_leaf_message(seq: Int) => Matrix[Real] {
+    if (seq == 0) { // "A"
        let message = rvecCreate(4, [1.0, 0.0, 0.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 1)) { // "C"
+    if (seq == 1) { // "C"
         let message = rvecCreate(4, [0.0, 1.0, 0.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 2)) { // "G"
+    if (seq == 2) { // "G"
         let message = rvecCreate(4, [0.0, 0.0, 1.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 3)) {  // "T"
+    if (seq == 3) {  // "T"
         let message = rvecCreate(4, [0.0, 0.0, 0.0, 1.0]);
         return message;
     }
-    if (eqi(seq, 4)) {  // "-"
+    if (seq == 4) {  // "-"
         let message = rvecCreate(4, [1.0, 1.0, 1.0, 1.0]);
         return message;
     }
@@ -76,7 +76,7 @@ function get_leaf_message(seq: Int) : Matrix[Real] {
 }
 
 //Compute log likelihood for each site
-function get_log_likes(msg: Matrix[Real]): Real {
+function get_log_likes(msg: Matrix[Real]) => Real {
     let stationary_probs = cvecCreate(4, [0.25,0.25,0.25,0.25]);
     let like = mtxMul(msg, stationary_probs);
     let log_like = log(mtxGet(1, 1, like));
@@ -84,12 +84,12 @@ function get_log_likes(msg: Matrix[Real]): Real {
 }
 
 // KEY FUNCTION: CLUSTER
-function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int): MsgTree[] {
+function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int) => MsgTree[] {
 
     let n = length(trees);
 
     // Check if we have reached the root of the tree
-    if (eqi(n, 1)) {
+    if (n == 1) {
         return trees;
     }
 
@@ -133,7 +133,7 @@ function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int):
     // Compute new_trees list
     let min = pairs[2];
     let max = pairs[1];
-    let new_trees = paste0([slice(trees, 1, min), slice(trees, addi(min, 1), max), slice(trees, addi(max, 1), addi(n, 1)), [parent]]);
+    let new_trees = paste0([slice(trees, 1, min), slice(trees, min + 1, max), slice(trees, max + 1, n + 1), [parent]]);
 
     // Recursive call to cluster for new_trees
     return cluster(q, new_trees, age, seq_len);
@@ -141,7 +141,7 @@ function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int):
 
 // MODEL FUNCTION
 
-model function myModel(data: Int[][]) : MsgTree[] {
+model function myModel(data: Int[][]) => MsgTree[] {
     // Define the scaled rate matrix for Jukes-Cantor
     let q = mtxCreate(4,4,
         [     -1.0, (1.0/3.0), (1.0/3.0), (1.0/3.0),

--- a/models/phylogeny/tree_inference_pruning_gtr.tppl
+++ b/models/phylogeny/tree_inference_pruning_gtr.tppl
@@ -28,7 +28,7 @@ type MsgTree =
 // FUNCTIONS
 
 // A help function to compute the scaled rate matrix for GTR
-function gtr(pi: Real[], r: Real[]) : Matrix[Real] {
+function gtr(pi: Real[], r: Real[]) => Matrix[Real] {
     // Construct a matrix of exchangeability rates
     let unscaled_q = mtxCreate(4,4,
                      [ -(pi[2]*r[1]+pi[3]*r[2]+pi[4]*r[3]),      pi[2]*r[1],                            pi[3]*r[2],                             pi[4]*r[3] ,
@@ -47,45 +47,45 @@ function gtr(pi: Real[], r: Real[]) : Matrix[Real] {
 }
 
 // Randomly sample two indices in the trees vector, to be combined. Avoiding mirror cases.
-function pickpair(n: Int): Int[] {
-    assume i_1 ~ Categorical(rep(subi(n, 1), 1./Real(subi(n, 1))));
-    let i = addi(i_1, 2); //Adding two, avoiding index zero for i and avoiding trouble picking j
-    assume j ~ Categorical(rep(subi(i, 1), 1./Real(subi(i, 1))));  // j is always smaller than i, avoiding mirror cases
-    return [i, addi(j, 1)]; //avoid index of zero for j
+function pickpair(n: Int) => Int[] {
+    assume i_1 ~ Categorical(rep(n - 1, 1./Real(n - 1)));
+    let i = i_1 + 2; //Adding two, avoiding index zero for i and avoiding trouble picking j
+    assume j ~ Categorical(rep(i - 1, 1./Real(i - 1)));  // j is always smaller than i, avoiding mirror cases
+    return [i, j + 1]; //avoid index of zero for j
 }
 
 // Build forest of trees from leaves, recursively
-function build_forest(data: Int[][], forest: MsgTree[], index: Int, data_len: Int, seq_len: Int): MsgTree[] {
+function build_forest(data: Int[][], forest: MsgTree[], index: Int, data_len: Int, seq_len: Int) => MsgTree[] {
     let new_message = sapply(data[index], get_leaf_message);
     let new_leaf = Leaf{age = 0.0, index = index, msg =  new_message};
     let new_forest = paste0([forest, [new_leaf]]);
-    if (eqi(data_len, index)) {
+    if (data_len == index) {
         return new_forest;
     }
     else {
-        return build_forest(data, new_forest, addi(index, 1), data_len, seq_len);
+        return build_forest(data, new_forest, index + 1, data_len, seq_len);
     }
 }
 
 // Get message from leaves for each site
-function get_leaf_message(seq: Int) : Matrix[Real] {
-    if (eqi(seq, 0)) { // "A"
+function get_leaf_message(seq: Int) => Matrix[Real] {
+    if (seq == 0) { // "A"
        let message = rvecCreate(4, [1.0, 0.0, 0.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 1)) { // "C"
+    if (seq == 1) { // "C"
         let message = rvecCreate(4, [0.0, 1.0, 0.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 2)) { // "G"
+    if (seq == 2) { // "G"
         let message = rvecCreate(4, [0.0, 0.0, 1.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 3)) {  // "T"
+    if (seq == 3) {  // "T"
         let message = rvecCreate(4, [0.0, 0.0, 0.0, 1.0]);
         return message;
     }
-    if (eqi(seq, 4)) {  // "-"
+    if (seq == 4) {  // "-"
         let message = rvecCreate(4, [1.0, 1.0, 1.0, 1.0]);
         return message;
     }
@@ -95,7 +95,7 @@ function get_leaf_message(seq: Int) : Matrix[Real] {
 }
 
 //Compute log likelihood for each site
-function get_log_likes(msg: Matrix[Real], pi: Real[]): Real {
+function get_log_likes(msg: Matrix[Real], pi: Real[]) => Real {
     let stationary_probs = cvecCreate(4, pi);
     let like = mtxMul(msg, stationary_probs);
     let log_like = log(mtxGet(1, 1, like));
@@ -103,12 +103,12 @@ function get_log_likes(msg: Matrix[Real], pi: Real[]): Real {
 }
 
 // KEY FUNCTION: CLUSTER
-function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int, pi: Real[]): MsgTree[] {
+function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int, pi: Real[]) => MsgTree[] {
 
     let n = length(trees);
 
     // Check if we have reached the root of the tree
-    if (eqi(n, 1)) {
+    if (n == 1) {
         return trees;
     }
 
@@ -152,7 +152,7 @@ function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int, 
     // Compute new_trees list
     let min = pairs[2];
     let max = pairs[1];
-    let new_trees = paste0([slice(trees, 1, min), slice(trees, addi(min, 1), max), slice(trees, addi(max, 1), addi(n, 1)), [parent]]);
+    let new_trees = paste0([slice(trees, 1, min), slice(trees, min + 1, max), slice(trees, max + 1, n + 1), [parent]]);
 
     // Recursive call to cluster for new_trees
     return cluster(q, new_trees, age, seq_len, pi);
@@ -160,7 +160,7 @@ function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int, 
 
 // MODEL FUNCTION
 
-model function myModel(data: Int[][]) : MsgTree[] {
+model function myModel(data: Int[][]) => MsgTree[] {
     // Sample stationary probs and exchangeability rates [r_AC, r_AG, r_AT, r_CG, r_CT, r_GT]
     assume pi ~ Dirichlet([1.0, 1.0, 1.0, 1.0]);
     assume er ~  Dirichlet([1.0, 1.0, 1.0, 1.0, 1.0, 1.0]);

--- a/models/phylogeny/tree_inference_pruning_scaled.tppl
+++ b/models/phylogeny/tree_inference_pruning_scaled.tppl
@@ -28,45 +28,45 @@ type MsgTree =
 // FUNCTIONS
 
 // Randomly sample two indices in the trees vector, to be combined. Avoiding mirror cases.
-function pickpair(n: Int): Int[] {
-    assume i_1 ~ Categorical(rep(subi(n, 1), 1./Real(subi(n, 1))));
-    let i = addi(i_1, 2); //Adding two, avoiding index zero for i and avoiding trouble picking j
-    assume j ~ Categorical(rep(subi(i, 1), 1./Real(subi(i, 1))));  // j is always smaller than i, avoiding mirror cases
-    return [i, addi(j, 1)]; //avoid index of zero for j
+function pickpair(n: Int) => Int[] {
+    assume i_1 ~ Categorical(rep(n - 1, 1./Real(n - 1)));
+    let i = i_1 + 2; //Adding two, avoiding index zero for i and avoiding trouble picking j
+    assume j ~ Categorical(rep(i - 1, 1./Real(i - 1)));  // j is always smaller than i, avoiding mirror cases
+    return [i, j + 1]; //avoid index of zero for j
 }
 
 // Build forest of trees from leaves, recursively
-function build_forest(data: Int[][], forest: MsgTree[], index: Int, data_len: Int, seq_len: Int): MsgTree[] {
+function build_forest(data: Int[][], forest: MsgTree[], index: Int, data_len: Int, seq_len: Int) => MsgTree[] {
     let new_message = sapply(data[index], get_leaf_message);
     let new_leaf = Leaf{age = 0.0, index = index, msg =  new_message};
     let new_forest = paste0([forest, [new_leaf]]);
-    if (eqi(data_len, index)) {
+    if (data_len == index) {
         return new_forest;
     }
     else {
-        return build_forest(data, new_forest, addi(index, 1), data_len, seq_len);
+        return build_forest(data, new_forest, index + 1, data_len, seq_len);
     }
 }
 
 // Get message from leaves for each site
-function get_leaf_message(seq: Int) : Matrix[Real] {
-    if (eqi(seq, 0)) { // "A"
+function get_leaf_message(seq: Int) => Matrix[Real] {
+    if (seq == 0) { // "A"
        let message = rvecCreate(4, [1.0, 0.0, 0.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 1)) { // "C"
+    if (seq == 1) { // "C"
         let message = rvecCreate(4, [0.0, 1.0, 0.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 2)) { // "G"
+    if (seq == 2) { // "G"
         let message = rvecCreate(4, [0.0, 0.0, 1.0, 0.0]);
         return message;
     }
-    if (eqi(seq, 3)) {  // "T"
+    if (seq == 3) {  // "T"
         let message = rvecCreate(4, [0.0, 0.0, 0.0, 1.0]);
         return message;
     }
-    if (eqi(seq, 4)) {  // "-"
+    if (seq == 4) {  // "-"
         let message = rvecCreate(4, [1.0, 1.0, 1.0, 1.0]);
         return message;
     }
@@ -76,24 +76,24 @@ function get_leaf_message(seq: Int) : Matrix[Real] {
 }
 
 // Get factor for each message
-function get_factor(msg: Matrix[Real]): Real {
+function get_factor(msg: Matrix[Real]) => Real {
     let factor = mtxGet(1, 1, msg) + mtxGet(1, 2, msg) + mtxGet(1, 3, msg) + mtxGet(1, 4, msg);
     return factor;
 }
 
 // Normalise message for each site
-function norm_mess(msg: Matrix[Real], factor: Real): Matrix[Real] {
+function norm_mess(msg: Matrix[Real], factor: Real) => Matrix[Real] {
     let norm_msg = rvecCreate(4, [mtxGet(1, 1, msg)/factor, mtxGet(1, 2, msg)/factor, mtxGet(1, 3, msg)/factor, mtxGet(1, 4, msg)/factor]);
     return norm_msg;
 }
 
 // KEY FUNCTION: CLUSTER
-function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int): MsgTree[] {
+function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int) => MsgTree[] {
 
     let n = length(trees);
 
     // Check if we have reached the root of the tree
-    if (eqi(n, 1)) {
+    if (n == 1) {
 
         // Stationarity at root
         let stationary = rep(seq_len, 0.25);
@@ -135,7 +135,7 @@ function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int):
     // Compute new_trees list
     let min = pairs[2];
     let max = pairs[1];
-    let new_trees = paste0([slice(trees, 1, min), slice(trees, addi(min, 1), max), slice(trees, addi(max, 1), addi(n, 1)), [parent]]);
+    let new_trees = paste0([slice(trees, 1, min), slice(trees, min + 1, max), slice(trees, max + 1, n + 1), [parent]]);
 
     // Recursive call to cluster for new_trees
     return cluster(q, new_trees, age, seq_len);
@@ -143,7 +143,7 @@ function cluster(q: Matrix[Real], trees: MsgTree[], maxAge: Real, seq_len: Int):
 
 // MODEL FUNCTION
 
-model function myModel(data: Int[][]) : MsgTree[] {
+model function myModel(data: Int[][]) => MsgTree[] {
     // Define the scaled rate matrix for Jukes-Cantor
     let q = mtxCreate(4,4,
         [     -1.0, (1.0/3.0), (1.0/3.0), (1.0/3.0),

--- a/src/lib/standard.mc
+++ b/src/lib/standard.mc
@@ -1,275 +1,11 @@
--- Exposes CorePPL features to TreePPL as part of a standard library
--- Intrinsics have to be exposed as top level let bindings
+-- Supporting MCore code for the TreePPL standard library (which can
+-- be found in `standard.tppl`)
 
 include "common.mc"
 include "string.mc"
-include "mexpr/ast.mc"
+include "ext/math-ext.mc"
 include "ext/mat-ext.mc"
-include "iterator.mc"
-include "ext/dist-ext.mc"
 include "seq.mc"
-
-let error = lam x. error x
-
-let subf = lam x. subf x
-let muli = lam x. muli x
-let addi = lam x. addi x
-let subi = lam x. subi x
-let eqi = lam x. eqi x
-let neqi = lam x. neqi x
-let geqi = lam x. geqi x
-let gti = lam x. gti x
-
-let log = lam x. log x
-let exp = lam x. exp x
-let sqrt = lam x. sqrt x
-
-let slice = lam seq. lam beg. lam mend.
-    subsequence seq (subi beg 1) (subi mend beg)
-
-
-----------------------------
---- Printing and strings ---
-----------------------------
-
-let concat = lam x. concat x
-
-let paste0 = lam x. join x
-
-let paste = lam seq. lam sep.
-  strJoin sep seq
-
-utest paste0 ["a", "b", "c"] with "abc" using eqString
-utest paste ["a", "b", "c"] " " with "a b c" using eqString
-utest paste ["a", "b", "c"] ", " with "a, b, c" using eqString
-
--- In TreePPL "printing" is only for debugging purposes
-let print = lam s.
-  printError s;
-  flushStderr ()
-
-let printLn = lam s.
-  printError (join [s, "\n"]);
-  flushStderr ()
-
-let int2string = lam x. int2string x
-
-let real2string = lam x. float2string x
-
-let bool2string: Bool -> String  = lam b.
-  if b then
-    "True"
-  else
-    "False"
-
------------------
---- Sequences ---
------------------
-
-let length = lam x.
-  length x
-
-let zipWith = lam x. zipWith x
-
-let fold = lam x.
-  foldl x
-
-let qSort = lam f. lam seq.
-  quickSort f seq
-
-let any = any
-
-let zipWith = zipWith
-
--- sapply1 for passing 1 argument (a) to function f
-let sapply1 = lam x. lam f. lam a.
-  map (lam e. f e a) x
-
--- switching the order of map to make it more R-like
--- the "etymology" should be understood as
--- "sequence" apply, even though in R it is something slightly different
--- sapply == for sequences, tapply == for tensors
-let sapply = lam x. lam f.
-  map f x
-
-let tapply = lam x. lam f.
-  create (muli x.m x.n) (lam i. f (extArrGetExn x.arr i))
-
--- sapply1 for passing 1 argument (a) to function f
-let sapply1 = lam x. lam f. lam a.
-  map (lam e. f e a) x
-
--- sapplyi1 is a mapping that additionally passes the current index and one argument a
-let sapplyi1 = lam x. lam f. lam a.
-  mapi (lam i. lam e. f (addi i 1) e a) x
-
--- sapplyi2 is a mapping that additionally passes the current index and two arguments (a and b)
-let sapplyi2 = lam x. lam f. lam a. lam b.
-  mapi (lam i. lam e. f (addi i 1) e a b) x
-
--- convert an integer sequences to a real sequence
-let sint2real = lam seq.
-  sapply seq int2float -- using the Miking function as tppl equiv only below
-
--- convert a real sequence to a string (useful for printing)
-let sreal2string = lam seq.
-  sapply seq real2string
-
--- convert a int sequence to a string (useful for printing)
-let sint2string = lam seq.
-  sapply seq int2string
-
--- convert a bool sequence to a string (useful for printing)
-let sbool2string = lam seq.
-  sapply seq bool2string
-
--- remap make to rep to make it more R-like
-let rep = lam x. make x
-
--- WebPPL inspired
-let repApply = lam x. create x
-
--- Sequence normalization
-let seqNormalize = lam seq.
-  let sum = foldl addf 0. seq in
-  map (lam f. divf f sum) seq
-
-utest seqNormalize [1.0, 1.0] with [0.5, 0.5] using (eqSeq eqf)
-
--- Find elements of a sequence that are true
-let whichTrue = lam elems.
-  foldli (lam acc. lam i. lam x. if x then snoc acc (addi i 1) else acc) [] elems
-
--- Test cases
-utest whichTrue [true, false, true, true, false] with [1, 3, 4]
-utest whichTrue [false, false, false] with []
-utest whichTrue [] with []
-
--- Sum all elements of a sequence
-let seqSumReal = lam seq.
-  foldl (lam acc. lam x. addf acc x) 0.0 seq
-
-utest seqSumReal [1., 2., 3., 4., 5.] with divf (mulf 5. 6.) 2. using eqf
-
--- Sum all elements of a sequence (int)
-let seqSumInt = lam seq.
-  foldl (lam acc. lam x. addi acc x) 0 seq
-
-utest seqSumInt [1, 2, 3, 4, 5] with 15 using eqi
-
-
-----------------
---- Matrices ---
-----------------
-
-type Matrix a = Mat a
-
-let int2real = lam x. int2float x -- we can also use the compiler built-in Real(x)
-
-let dim = lam mtx. [mtx.m, mtx.n]
-
-let mtxMul = matMulExn
-
-let mtxSclrMul = matScale
-
-let mtxAdd = matAddExn
-
-let mtxElemMul = matElemMulExn
-
-let mtxTrans = matTranspose
-
-let mtxExp = matExpExn
-
-let mtxGet = lam row. lam col. lam mtx.
-  matGetExn mtx (subi row 1) (subi col 1)
-
-let mtxGetRow : all a. Int -> Matrix a -> Matrix a = lam row. lam mtx.
-  let new = matMakeUninit (externalExtArrKind mtx.arr) 1 mtx.n in
-  let r = subi row 1 in
-  -- OPT(vipa, 2025-03-07): Working with individual cells is likely
-  -- inefficient
-  repeati (lam i. matSetExn new 0 i (matGetExn mtx r i)) mtx.n;
-  new
-
--- we cannot change the function parametrization and keep the same name
--- will bring confusion
-let mtxCreate = lam row. lam col. lam seq.
-  matFromArrExn row col (extArrOfSeq extArrKindFloat64 seq)
-
-let mtxCreateId = lam dim.
-  let mat = matMake extArrKindFloat64 dim dim 0.0 in
-  repeati (lam i. matSetExn mat i i 1.0) dim;
-  mat
-
-utest extArrToSeq (mtxCreateId 2).arr with [1., 0., 0., 1.] using (eqSeq eqf)
-utest extArrToSeq (mtxCreateId 3).arr with [1., 0., 0., 0., 1., 0., 0., 0., 1.] using (eqSeq eqf)
-
-let rvecCreate = lam cols. lam seq.
-  matFromArrExn 1 cols (extArrOfSeq extArrKindFloat64 seq)
-let cvecCreate = lam rows. lam seq.
-  matFromArrExn rows 1 (extArrOfSeq extArrKindFloat64 seq)
-
-
--- matrix exponentiation
-recursive let mtxPow = lam mtx: Matrix Float. lam pow: Int.
-  if not (matIsSquare mtx) then
-    error "Matrix must be square"
-  else if eqi pow 0 then
-    mtxCreateId mtx.m -- Assuming a squareMatrix
-  else if eqi pow 1 then
-    mtx
-  else if eqi (modi pow 2) 0 then
-    let halfPow = mtxPow mtx (divi pow 2) in
-    mtxMul halfPow halfPow
-  else
-    mtxMul mtx (mtxPow mtx (subi pow 1))
-end
-
-utest extArrToSeq (mtxPow (mtxCreateId 3) 3).arr with [1., 0., 0., 0., 1., 0., 0., 0., 1.] using (eqSeq eqf)
-
--- Define the matrix
-let __test_43FS35GF: Matrix Float = mtxCreate 3 3 [
-  1., 2., 3.,
-  4., 5., 6.,
-  7., 8., 9.
-]
-
-
--- Test for exponent 0
-utest extArrToSeq (mtxPow __test_43FS35GF 0).arr with [1., 0., 0., 0., 1., 0., 0., 0., 1.] using (eqSeq eqf)
-
--- Test for exponent 1
-utest extArrToSeq (mtxPow __test_43FS35GF 1).arr with [1., 2., 3., 4., 5., 6., 7., 8., 9.] using (eqSeq eqf)
-
--- Test for exponent 2
-utest extArrToSeq (mtxPow __test_43FS35GF 2).arr with [30., 36., 42., 66., 81., 96., 102., 126., 150.] using (eqSeq eqf)
-
--- Test for exponent 3
-utest extArrToSeq (mtxPow __test_43FS35GF 3).arr with [468., 576., 684., 1062., 1305., 1548., 1656., 2034., 2412.] using (eqSeq eqf)
-
--- Test for exponent 4
-utest extArrToSeq (mtxPow __test_43FS35GF 4).arr with [7560., 9288., 11016., 17118., 21033., 24948., 26676., 32778., 38880.] using (eqSeq eqf)
-
--- indexing from 1, not from 0!
-
-let mtxSclrMul = lam scalar. lam tensor.
-  matScale scalar tensor
-
-let iid = lam f. lam p. lam n.
-  let params = make n p in
-  map f params
-
--- Retrieve a row vector with the columns in cols
--- TODO(mariana/vipa, 2023-10-09): the idea is to have mtxRowCols, mtxRowsCol, and mtxRowsCols
--- if we get the appropriate form of overloading we could make indexing (a[idxs])
--- call the correct one of those later on
-let mtxRowCols = lam matrix. lam row. lam cols.
-  let r = subi row 1 in
-  let new = matMakeUninit (externalExtArrKind matrix.arr) 1 (length cols) in
-  -- OPT(vipa, 2025-03-07): Working with individual cells is likely
-  -- inefficient
-  iteri (lam i. lam c. matSetExn new 0 i (matGetExn matrix r (subi c 1))) cols;
-  new
 
 let _iterateni = lam bound. lam f.
   recursive let work = lam i. lam acc.
@@ -278,47 +14,69 @@ let _iterateni = lam bound. lam f.
     else acc
   in work 0
 
--- Mean of a tensor (e.g., vectors and matrices)
--- Was commented out by Viktor, used now by Mariana
-let mtxMean = lam t.
+let printStd = print
+let printErr = printError
+let crash = error
+
+let seqSnoc = snoc
+let seqCons = cons
+let seqCreate = create
+let seqConcat = concat
+let seqLength = length
+let seqMap = map
+let seqMapi = mapi
+let seqZipWith = zipWith
+let seqSubsequence = subsequence
+let seqFoldl = foldl
+let seqFoldli = foldli
+let seqAny = any
+
+let float2string = float2string
+let const_int2string = int2string
+
+let mathExp = exp
+let mathLog = log
+let mathSqrt = sqrt
+let mathModi = modi
+
+-- NOTE(vipa, 2025-05-05): Some of the functions below use the
+-- internal mutability of matrices for their workings. This ok,
+-- because these mutations are never observable; we mutate matrices
+-- that are created here, and then never mutate them after returning.
+let matNumRows : all x. Mat x -> Int = lam mtx. mtx.m
+let matNumCols : all x. Mat x -> Int = lam mtx. mtx.n
+let matNormalize = lam mtx.
+  let sum = _iterateni (muli mtx.m mtx.n) (lam i. lam acc. addf acc (extArrGetExn mtx.arr i)) 0.0 in
+  let mtx = matCopy mtx in
+  repeati (lam i. extArrSetExn mtx.arr i (divf (extArrGetExn mtx.arr i) sum)) (muli mtx.m mtx.n);
+  mtx
+let matGetRow : all a. Int -> Mat a -> Mat a = lam row. lam mtx.
+  let new = matMakeUninit (externalExtArrKind mtx.arr) 1 mtx.n in
+  let r = subi row 1 in
+  -- OPT(vipa, 2025-03-07): Working with individual cells is likely
+  -- inefficient
+  repeati (lam i. matSetExn new 0 i (matGetExn mtx r i)) mtx.n;
+  new
+let matElemPow = lam mtx. lam f.
+  let mtx = matCopy mtx in
+  -- OPT(vipa, 2025-03-07): Working with individual cells is likely
+  -- inefficient
+  repeati (lam i. extArrSetExn mtx.arr i (pow (extArrGetExn mtx.arr i) f)) (muli mtx.m mtx.n);
+  mtx
+let matMean = lam t.
   -- OPT(vipa, 2025-03-07): Working with individual cells is likely
   -- inefficient
   let sum = _iterateni (muli t.m t.n) (lam i. lam acc. addf acc (extArrGetExn t.arr i)) 0.0 in
   divf sum (int2float (muli t.m t.n))
-
-let __test_tesnor1: Matrix Float = mtxCreate 3 3 [
-    1., 1., 1.,
-    2., 2., 2.,
-    3., 3., 3.
-  ]
-
-utest mtxMean __test_tesnor1 with 2. using eqf
-
-let mtxNormalize = lam v.
-  let sum = _iterateni (muli v.m v.n) (lam i. lam acc. addf acc (extArrGetExn v.arr i)) 0.0 in
-  let v = matCopy v in
-  repeati (lam i. extArrSetExn v.arr i (divf (extArrGetExn v.arr i) sum)) (muli v.m v.n);
-  v
-
-let mtxElemPow = lam mtx. lam f.
-  let mtx = matCopy mtx in
-  repeati (lam i. extArrSetExn mtx.arr i (pow (extArrGetExn mtx.arr i) f)) (muli mtx.m mtx.n);
-  mtx
-
-----------------
---- Messages ---
-----------------
-
--- NOTE(mariana, 2023-10-05): attempt to use functions Daniel wrote
--- to handle Messages, which are Tensor[Real][]
-
--- Message normalization
-let messageNormalize = lam m.
-  map mtxNormalize m
-
--- Elementwise multiplication of state likelihoods/probabilities
-let messageElemMul = zipWith mtxElemMul
-
--- Raises each element to the power of the float argument
-let messageElemPow = lam m. lam f.
-    map (lam v. mtxElemPow v f) m
+let matApplyToSeq : all a. all b. Mat a -> (a -> b) -> [b] = lam x. lam f.
+  create (muli x.m x.n) (lam i. f (extArrGetExn x.arr i))
+-- TODO(mariana/vipa, 2023-10-09): the idea is to have mtxRowCols, mtxRowsCol, and mtxRowsCols
+-- if we get the appropriate form of overloading we could make indexing (a[idxs])
+-- call the correct one of those later on
+let matRowCols = lam matrix. lam row. lam cols.
+  let r = subi row 1 in
+  let new = matMakeUninit (externalExtArrKind matrix.arr) 1 (length cols) in
+  -- OPT(vipa, 2025-03-07): Working with individual cells is likely
+  -- inefficient
+  iteri (lam i. lam c. matSetExn new 0 i (matGetExn matrix r (subi c 1))) cols;
+  new

--- a/src/lib/standard.tppl
+++ b/src/lib/standard.tppl
@@ -1,10 +1,344 @@
 import "stdlib::ext/dist-ext.mc"
 import "stdlib::seq.mc"
 import "stdlib::string.mc"
+import "stdlib::common.mc"
+import "stdlib::ext/arr-ext.mc"
+import "stdlib::ext/mat-ext.mc"
+import "./standard.mc"
 
 type Tree =
   | Leaf {age: Real}
   | Node {left: Tree, right: Tree, age: Real}
+
+
+/* -----------------------
+   Mathematical operations
+   ----------------------- */
+
+function exp(x : Real) => Real {
+  return mathExp(x);
+}
+
+function log(x : Real) => Real {
+  return mathLog(x);
+}
+
+function sqrt(x : Real) => Real {
+  return mathSqrt(x);
+}
+
+
+/* -------------------
+   Sequence operations
+   ------------------- */
+
+function rep[X](count : Int, elem : X) => X[] {
+  return make(count)(elem);
+}
+
+function repApply[X](count : Int, f : Function(Int) => X) => X[] {
+  return seqCreate(count)(function(idx:Int) => X { return f(idx + 1); });
+}
+
+function iid[A, B](f : Function(A)=>B, a : A, count : Int) => B[] {
+  return seqCreate(count)(function(idx:Int) => B { return f(a); });
+}
+
+function concat[X](l : X[], r : X[]) => X[] {
+  return seqConcat(l)(r);
+}
+
+function paste0[X](l : X[][]) => X[] {
+  return join(l);
+}
+
+function paste[X](l : X[][], sep : X[]) => X[] {
+  return seqJoin(sep)(l);
+}
+
+function slice[X](l : X[], first : Int, last : Int) => X[] {
+  return seqSubsequence(l)(first - 1)(last - first);
+}
+
+function length[X](l : X[]) => Int {
+  return seqLength(l);
+}
+
+function sapply[A, B](s : A[], f : Function(A)=>B) => B[] {
+  return seqMap(f)(s);
+}
+
+function sapplyi[A, B](s : A[], f : Function(Int, A)=>B) => B[] {
+  return seqMapi(function(i : Int) => Function(A) => B {return function(x : A) => B {return f(i+1, x);};})(s);
+}
+
+function fold[A, B](f : Function(A, B)=>A, init : A, seq : B[]) => A {
+  return seqFoldl(function(a : A) => Function(B) => A {return function(b : B) => A {return f(a, b);};})(init)(seq);
+}
+
+function foldi[A, B](f : Function(A, Int, B)=>A, init : A, seq : B[]) => A {
+  return seqFoldli(function(a : A) => Function(Int) => Function(B) => A {return function(idx : Int) => Function(B) => A {return function(b : B) => A {return f(a, idx+1, b);};};})(init)(seq);
+}
+
+// TODO(vipa, 2025-04-30): This can be replaced with `sapply(xs, f(_, b))` with partial application
+function sapply1[A, B, C](s : A[], f : Function(A, B)=>C, b : B) => C[] {
+  return sapply(s, function(e : A) => C { return f(e, b); });
+}
+
+// TODO(vipa, 2025-04-30): This can be replaced with `sapplyi(xs, f(_, _, b))` with partial application
+function sapplyi1[A, B, C](s : A[], f : Function(Int, A, B)=>C, b : B) => C[] {
+  return sapplyi(s, function(i : Int, a : A) => C {return f(i, a, b);});
+}
+
+// TODO(vipa, 2025-04-30): This can be replaced with `sapplyi(xs, f(_, _, b, c))` with partial application
+function sapplyi2[A, B, C, D](s : A[], f : Function(Int, A, B, C)=>D, b : B, c : C) => D[] {
+  return sapplyi(s, function(i : Int, a : A) => D {return f(i, a, b, c);});
+}
+
+function zipWith[A, B, C](f : Function(A, B) => C, a : A[], b : B[]) => C[] {
+  return seqZipWith(function(a : A) => Function(B) => C {return function(b : B) => C {return f(a, b);};})(a)(b);
+}
+
+function seqSumReal(s : Real[]) => Real {
+  return fold(function(a : Real, b : Real) => Real {return a + b;}, 0.0, s);
+}
+
+function seqSumInt(s : Int[]) => Int {
+  return fold(function(a : Int, b : Int) => Int {return a + b;}, 0, s);
+}
+
+function seqNormalize(s : Real[]) => Real[] {
+  let sum = seqSumReal(s);
+  return sapply(s, function(x : Real) => Real {return x / sum;});
+}
+
+function any[X](f : Function(X) => Bool, l : X[]) => Bool {
+  return seqAny(f)(l);
+}
+
+function qSort[X](cmp : Function(X, X)=>Int, l : X[]) => X[] {
+  return quickSort(function(a : X) => Function(X) => Int {return function(b : X) => Int {return cmp(a, b);};})(l);
+}
+
+function whichTrue(s : Bool[]) => Int[] {
+  return foldi(function(acc : Int[], idx : Int, elem : Bool) => Int[] {
+    if elem {
+      return seqSnoc(acc)(idx);
+    }
+    return acc;
+  }, [], s);
+}
+
+
+/* -----------
+   Conversions
+   ----------- */
+
+function real2string(v : Real) => String {
+  return float2string(v);
+}
+
+function sreal2string(v : Real[]) => String[] {
+  return sapply(v, float2string);
+}
+
+function int2string(v : Int) => String {
+  return const_int2string(v);
+}
+
+function sint2string(v : Int[]) => String[] {
+  return sapply(v, int2string);
+}
+
+function int2real(v : Int) => Real {
+  return Real(v);
+}
+
+function sint2real(v : Int[]) => Real[] {
+  return sapply(v, int2real);
+}
+
+function bool2real(v : Bool) => Real {
+  if (v) {
+    return 1.0;
+  }
+  return 0.0;
+}
+
+function sbool2real(v : Bool[]) => Real[] {
+  return sapply(v, bool2real);
+}
+
+function bool2string(v: Bool) => String {
+  if (v) {
+     return "true";
+  }
+  return "false";
+}
+
+function sbool2string(v : Bool[]) => String[] {
+  return sapply(v, bool2string);
+}
+
+
+/* -----------------------------
+   Matrices and their operations
+   ----------------------------- */
+
+type alias Matrix[X] = Mat[X]
+
+function mtxCreate(rows : Int, cols : Int, data : Real[]) => Matrix[Real] {
+  return matFromArrExn(rows)(cols)(extArrOfSeq(extArrKindFloat64)(data));
+}
+
+function mtxCreateId(sideLength : Int) => Matrix[Real] {
+  let mat = matMake(extArrKindFloat64)(sideLength)(sideLength)(0.0);
+  repeati(function(i : Int) {return matSetExn(mat)(i)(i)(1.0);})(sideLength);
+  return mat;
+}
+
+function rvecCreate(cols : Int, seq : Real[]) => Matrix[Real] {
+  return matFromArrExn(1)(cols)(extArrOfSeq(extArrKindFloat64)(seq));
+}
+
+function cvecCreate(rows : Int, seq : Real[]) => Matrix[Real] {
+  return matFromArrExn(rows)(1)(extArrOfSeq(extArrKindFloat64)(seq));
+}
+
+function dim[X](mtx : Matrix[X]) => Int[] {
+  return [matNumRows(mtx), matNumCols(mtx)];
+}
+
+function mtxGet[X](row : Int, col : Int, mtx : Matrix[X]) => X {
+  return matGetExn(mtx)(row - 1)(col - 1);
+}
+
+function mtxRowCols[X](mtx : Matrix[X], row : Int, cols : Int[]) => Matrix[X] {
+  return matRowCols(mtx)(row)(cols);
+}
+
+function mtxSclrMul(scalar : Real, mtx : Matrix[Real]) => Matrix[Real] {
+  return matScale(scalar)(mtx);
+}
+
+function mtxAdd(a : Matrix[Real], b : Matrix[Real]) => Matrix[Real] {
+  return matAddExn(a)(b);
+}
+
+function mtxTrans(mtx : Matrix[Real]) => Matrix[Real] {
+  return matTranspose(mtx);
+}
+
+function mtxExp(mtx : Matrix[Real]) => Matrix[Real] {
+  return matExpExn(mtx);
+}
+
+function mtxMul(a : Matrix[Real], b : Matrix[Real]) => Matrix[Real] {
+  return matMulExn(a)(b);
+}
+
+function mtxElemMul(a : Matrix[Real], b : Matrix[Real]) => Matrix[Real] {
+  return matElemMulExn(a)(b);
+}
+
+function mtxElemPow(mtx : Matrix[Real], pow : Real) => Matrix[Real] {
+  return matElemPow(mtx)(pow);
+}
+
+function mtxNormalize(mtx : Matrix[Real]) => Matrix[Real] {
+  return matNormalize(mtx);
+}
+
+function mtxGetRow[X](row : Int, mtx : Matrix[X]) => Matrix[X] {
+  return matGetRow(row)(mtx);
+}
+
+function _mtxPow(mtx : Matrix[Real], pow : Int) => Matrix[Real] {
+  if pow == 1 {
+     return mtx;
+  }
+  if mathModi(pow)(2) == 0 {
+     let halfPow = _mtxPow(mtx, pow/2);
+     return mtxMul(halfPow, halfPow);
+  }
+  return mtxMul(mtx, _mtxPow(mtx, pow-1));
+}
+
+function mtxPow(mtx : Matrix[Real], pow : Int) => Matrix[Real] {
+  if !matIsSquare(mtx) {
+     return error("Matrix must be square");
+  }
+  if pow < 0 {
+     return error("Powers must be non-negative");
+  }
+  if pow == 0 {
+     return mtxCreateId(matNumRows(mtx));
+  }
+  return _mtxPow(mtx, pow);
+}
+
+function mtxMean(mtx : Matrix[Real]) => Real {
+  return matMean(mtx);
+}
+
+function tapply[A, B](mtx : Matrix[A], f : Function(A)=>B) => B[] {
+  return matApplyToSeq(mtx)(f);
+}
+
+/* ---------------------
+   Phylogenetic messages
+   --------------------- */
+
+type alias Message = Matrix[Real][]
+
+function messageElemMul(a : Message, b : Message) => Message {
+  return zipWith(mtxElemMul, a, b);
+}
+
+function messageElemPow(a : Message, pow : Real) => Message {
+  // return sapply(a, mtxElemPow(_, pow));
+  return sapply(a, function(v : Matrix[Real]) => Matrix[Real] {return mtxElemPow(v, pow);});
+}
+
+function messageNormalize(m : Message) => Message {
+  return sapply(m, mtxNormalize);
+}
+
+
+/* --------------
+   Debug printing
+   -------------- */
+
+function error[A](msg : String) => A {
+  return crash(msg);
+}
+
+function print(msg : String) {
+  printErr(msg);
+}
+
+function printLn(msg : String) {
+  printErrorLn(msg);
+}
+
+function printMtx(m: Matrix[Real]) {
+  let dimensions = dim(m);
+  printErrorLn( join( [ "[[ "
+                 , int2string( dimensions[1] )
+                 , " x "
+                 , int2string( dimensions[2] )
+                 , " matrix ]]:"
+                 ]
+               )
+         );
+  for i in 1 to (dimensions[1]) {
+    for j in 1 to (dimensions[2]) {
+      printErr(concat(real2string(mtxGet(i, j, m)), "\t"));
+    }
+    printErrorLn("");
+  }
+  printErrorLn("");
+}
 
 
 /* -----------------------------------------------------------
@@ -18,18 +352,18 @@ type UniformParam = UniformParam {
 }
 
 // wrapper for iid
-function uniform(param: UniformParam): Real {
+function uniform(param: UniformParam) => Real {
   assume x ~ Uniform(param.a, param.b);
   return x;
 }
 
 // log-score
-function uniformLogScore(x:Real, param: UniformParam): Real {
-  return uniformContinuousLogPdf(param.a, param.b, x);
+function uniformLogScore(x:Real, param: UniformParam) => Real {
+  return uniformContinuousLogPdf(param.a)(param.b)(x);
 }
 
-function uniformScore(x:Real, param: UniformParam): Real {
-  return uniformContinuousPdf(param.a, param.b, x);
+function uniformScore(x:Real, param: UniformParam) => Real {
+  return uniformContinuousPdf(param.a)(param.b)(x);
 }
 
 
@@ -38,17 +372,17 @@ type BernoulliParam = BernoulliParam {
   prob: Real
 }
 
-function bernoulli(param: BernoulliParam): Bool {
+function bernoulli(param: BernoulliParam) => Bool {
   assume x ~ Bernoulli(param.prob);
   return x;
 }
 
-function bernoulliLogScore(x: Bool, param: BernoulliParam): Real {
-  return bernoulliLogPmf(param.prob, x);
+function bernoulliLogScore(x: Bool, param: BernoulliParam) => Real {
+  return bernoulliLogPmf(param.prob)(x);
 }
 
-function bernoulliScore(x: Bool, param: BernoulliParam): Real {
-  return bernoulliPmf(param.prob, x);
+function bernoulliScore(x: Bool, param: BernoulliParam) => Real {
+  return bernoulliPmf(param.prob)(x);
 }
 
 
@@ -57,17 +391,17 @@ type ExponentialParam = ExponentialParam {
   rate: Real
 }
 
-function exponential(param: ExponentialParam): Real {
+function exponential(param: ExponentialParam) => Real {
   assume x ~ Exponential(param.rate);
   return x;
 }
 
-function exponentialLogScore(x: Real, param: ExponentialParam) {
-  return exponentialLogPdf(param.rate, x);
+function exponentialLogScore(x: Real, param: ExponentialParam) => Real {
+  return exponentialLogPdf(param.rate)(x);
 }
 
-function exponentialScore(x: Real, param: ExponentialParam) {
-  return exponentialPdf(param.rate, x);
+function exponentialScore(x: Real, param: ExponentialParam) => Real {
+  return exponentialPdf(param.rate)(x);
 }
 
 // Poisson
@@ -75,17 +409,17 @@ type PoissonParam = PoissonParam {
   rate: Real
 }
 
-function poisson(param: PoissonParam): Int {
+function poisson(param: PoissonParam) => Int {
   assume x ~ Poisson(param.rate);
   return x;
 }
 
-function poissonLogScore(x: Int, param: PoissonParam) {
-  return poissonLogPmf(param.rate, x);
+function poissonLogScore(x: Int, param: PoissonParam) => Real {
+  return poissonLogPmf(param.rate)(x);
 }
 
-function poissonScore(x: Int, param: PoissonParam) {
-  return poissonPmf(param.rate, x);
+function poissonScore(x: Int, param: PoissonParam) => Real {
+  return poissonPmf(param.rate)(x);
 }
 
 // Beta
@@ -94,17 +428,17 @@ type BetaParam = BetaParam {
   b: Real
 }
 
-function beta(param: BetaParam): Real {
+function beta(param: BetaParam) => Real {
   assume x ~ Beta(param.a, param.b);
   return x;
 }
 
-function betaLogScore(x: Real, param: BetaParam) {
-  return betaLogPdf(x, param.a, param.b);
+function betaLogScore(x: Real, param: BetaParam) => Real {
+  return betaLogPdf(x)(param.a)(param.b);
 }
 
-function betaScore(x: Real, param: BetaParam) {
-  return betaPdf(x, param.a, param.b);
+function betaScore(x: Real, param: BetaParam) => Real {
+  return betaPdf(x)(param.a)(param.b);
 }
 
 // Gamma
@@ -113,17 +447,17 @@ type GammaParam = GammaParam {
   scale: Real
 }
 
-function gamma(param: GammaParam): Real {
+function gamma(param: GammaParam) => Real {
   assume x ~ Gamma(param.shape, param.scale);
   return x;
 }
 
-function gammaLogScore(x: Real, param: GammaParam) {
-  return gammaLogPdf(param.shape, param.scale, x);
+function gammaLogScore(x: Real, param: GammaParam) => Real {
+  return gammaLogPdf(param.shape)(param.scale)(x);
 }
 
-function gammaScore(x: Real, param: GammaParam) {
-  return gammaPdf(param.shape, param.scale, x);
+function gammaScore(x: Real, param: GammaParam) => Real {
+  return gammaPdf(param.shape)(param.scale)(x);
 }
 
 // Categorical
@@ -131,17 +465,17 @@ type CategoricalParam = CategoricalParam {
   probs: Real[]
 }
 
-function categorical(param: CategoricalParam) {
+function categorical(param: CategoricalParam) => Int {
   assume x ~ Categorical(param.probs);
   return x;
 }
 
-function categoricalLogScore(x: Int, param: CategoricalParam) {
-  return categoricalLogPmf(param.probs, x);
+function categoricalLogScore(x: Int, param: CategoricalParam) => Real {
+  return categoricalLogPmf(param.probs)(x);
 }
 
-function categoricalScore(x: Int, param: CategoricalParam) {
-  return categoricalPmf(param.probs, x);
+function categoricalScore(x: Int, param: CategoricalParam) => Real {
+  return categoricalPmf(param.probs)(x);
 }
 
 // Multinomial
@@ -150,17 +484,17 @@ type MultinomialParam = MultinomialParam {
   probs: Real[]
 }
 
-function multinomial(param: MultinomialParam) {
+function multinomial(param: MultinomialParam) => Int[] {
   assume x ~ Multinomial(param.n, param.probs);
   return x;
 }
 
-function multinomialLogScore(x: Int[], param: MultinomialParam) {
-  return multinomialLogPmf(param.probs, x);
+function multinomialLogScore(x: Int[], param: MultinomialParam) => Real {
+  return multinomialLogPmf(param.probs)(x);
 }
 
-function multinomialScore(x: Int[], param: MultinomialParam) {
-  return multinomialPmf(param.probs, x);
+function multinomialScore(x: Int[], param: MultinomialParam) => Real {
+  return multinomialPmf(param.probs)(x);
 }
 
 // Dirichlet
@@ -168,17 +502,17 @@ type DirichletParam = DirichletParam {
   alphas: Real[]
 }
 
-function dirichlet(param: DirichletParam) {
+function dirichlet(param: DirichletParam) => Real[] {
   assume x ~ Dirichlet(param.alphas);
   return x;
 }
 
-function dirichletLogScore(x: Real[], param: DirichletParam) {
-  return dirichletLogPdf(param.alphas, x);
+function dirichletLogScore(x: Real[], param: DirichletParam) => Real {
+  return dirichletLogPdf(param.alphas)(x);
 }
 
-function dirichletScore(x: Real[], param: DirichletParam) {
-  return dirichletPdf(param.alphas, x);
+function dirichletScore(x: Real[], param: DirichletParam) => Real {
+  return dirichletPdf(param.alphas)(x);
 }
 
 // Empiricial
@@ -191,17 +525,17 @@ type GaussianParam = GaussianParam {
   dev: Real
 }
 
-function gaussian(param: GaussianParam) {
+function gaussian(param: GaussianParam) => Real {
   assume x ~ Gaussian(param.mean, param.dev);
   return x;
 }
 
-function gaussianLogScore(x: Real, param: GaussianParam) {
-  return gaussianLogPdf(param.mean, param.dev, x);
+function gaussianLogScore(x: Real, param: GaussianParam) => Real {
+  return gaussianLogPdf(param.mean)(param.dev)(x);
 }
 
-function gaussianScore(x: Real, param: GaussianParam) {
-  return gaussianPdf(param.mean, param.dev, x);
+function gaussianScore(x: Real, param: GaussianParam) => Real {
+  return gaussianPdf(param.mean)(param.dev)(x);
 }
 
 // Binomial
@@ -210,49 +544,15 @@ type BinomialParam = BinomialParam {
   prob: Real
 }
 
-function binomial(param: BinomialParam) {
+function binomial(param: BinomialParam) => Int {
   assume x ~ Binomial(param.n, param.prob);
   return x;
 }
 
-function binomialLogScore(x: Int, param: BinomialParam) {
-  return binomialLogPmf(param.prob, param.n, x);
+function binomialLogScore(x: Int, param: BinomialParam) => Real {
+  return binomialLogPmf(param.prob)(param.n)(x);
 }
 
-function binomialScore(x: Int, param: BinomialParam) {
-  return binomialPmf(param.prob, param.n, x);
-}
-
-
-/**
- *
- * Pretty prints a two-dimensional tensor
- *
- * @param m matrix
- * @return void
- */
-function printMtx(m: Matrix[Real]): () {
-  let dimensions = dim(m);
-  printLn( join( [ "[[ "
-                 , int2string( dimensions[1] )
-                 , " x "
-                 , int2string( dimensions[2] )
-                 , " matrix ]]:"
-                 ]
-               )
-         );
-  for i in 1 to (dimensions[1]) {
-    for j in 1 to (dimensions[2]) {
-      print(concat(real2string(mtxGet(i, j, m)), "\t"));
-    }
-    printLn("");
-  }
-  printLn("");
-}
-
-function bool2real(b: Bool): Real {
-  if (b) {
-    return 1.0;
-  }
-  return 0.0;
+function binomialScore(x: Int, param: BinomialParam) => Real {
+  return binomialPmf(param.prob)(param.n)(x);
 }

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -55,7 +55,6 @@ lang TreePPLCompile
     printJsonLn: Name,
     particles: Name, sweeps: Name, input: Name, some: Name,
     matrixMul: Name,
-    matrixPow: Name,
     matrixAdd: Name,
     matrixMulFloat: Name,
     pow: Name,
@@ -186,8 +185,8 @@ lang TreePPLCompile
 
   | NothingTypeTppl x -> tyunit_
 
-  sem compileModelInvocation : TpplCompileContext -> (Type -> Loader -> (Loader, InferMethod)) -> Loader -> DeclTppl -> Option (Loader, Expr)
-  sem compileModelInvocation context mkInferenceMethod loader =
+  sem compileModelInvocation : TpplCompileContext -> (Type -> Loader -> (Loader, InferMethod)) -> Loader -> SymEnv -> DeclTppl -> Option (Loader, SymEnv, Expr)
+  sem compileModelInvocation context mkInferenceMethod loader fileEnv =
   | FunDeclTppl (x & {model = Some modelInfo}) ->
     -- TODO(vipa, 2024-12-13): We could technically shadow a model
     -- function, in which case the generated code will refer to the
@@ -195,14 +194,13 @@ lang TreePPLCompile
     let params : [(Name, Type)] =
       map (lam param. (param.name.v, compileTypeTppl param.ty)) x.args in
 
-    let symEnv = _getSymEnv loader in
     let tcEnv = _getTCEnv loader in
     let inputType = tyrecord_ (map (lam x. (nameGetStr x.0, x.1)) params) in
-    let inputType = resolveType modelInfo tcEnv false (symbolizeType symEnv inputType) in
+    let inputType = resolveType modelInfo tcEnv false (symbolizeType fileEnv inputType) in
     let outputType = match x. returnTy with Some ty
       then compileTypeTppl ty
       else errorSingle [modelInfo] "A model function must have an explicit return type, even if it returns nothing, i.e., ()" in
-    let outputType = resolveType modelInfo tcEnv false (symbolizeType symEnv outputType) in
+    let outputType = resolveType modelInfo tcEnv false (symbolizeType fileEnv outputType) in
     match serializationPairsFor [inputType, outputType] loader with (loader, [inputSer, outputSer]) in
 
     let app_ = lam f. lam a. withInfo modelInfo (app_ f a) in
@@ -221,7 +219,7 @@ lang TreePPLCompile
       , tyBody = tyunknown_
       , info = modelInfo
       } in
-    let loader = _addDeclExn loader parsedDecl in
+    match _addDeclWithEnvExn fileEnv loader parsedDecl with (fileEnv, loader) in
 
     match mkInferenceMethod outputType loader with (loader, inferenceMethod) in
 
@@ -237,14 +235,14 @@ lang TreePPLCompile
         , ty = tyunknown_
         } in
 
-      let inferCode = appf2_ (nvar_ context.repeat)
-        (ulam_ ""
-          (app_ (nvar_ context.printJsonLn)
-            (appf2_ (nvar_ context.serializeResult) outputSer.serializer
-              (infer_ inferenceMethod
-                (ulam_ "" invocation)))))
-        (nvar_ context.sweeps) in
-    Some (loader, inferCode)
+    let inferCode = appf2_ (nvar_ context.repeat)
+      (ulam_ ""
+        (app_ (nvar_ context.printJsonLn)
+          (appf2_ (nvar_ context.serializeResult) outputSer.serializer
+            (infer_ inferenceMethod
+              (ulam_ "" invocation)))))
+      (nvar_ context.sweeps) in
+    Some (loader, fileEnv, inferCode)
   | _ -> None ()
 
   sem compileStmtTppl: TpplCompileContext -> StmtTppl -> (Expr -> Expr)
@@ -707,19 +705,6 @@ lang TreePPLCompile
       ty = tyunknown_
     }
 
-  | MatrixPowerExprTppl x ->
-    TmApp {
-        info = x.info,
-        lhs = TmApp {
-          info = x.info,
-          lhs = nvar_ context.matrixPow,
-          rhs = compileExprTppl context x.left,
-          ty = tyunknown_
-        },
-        rhs = compileExprTppl context x.right,
-        ty = tyunknown_
-      }
-
   | PowerExprTppl x ->
    TmApp {
         info = x.info,
@@ -999,7 +984,7 @@ lang TreePPLThings = TreePPLAst + TreePPLCompile
     -- Standard library (these should be in scope in the program)
     match includeFileExn "." "treeppl::lib/standard.mc" loader with (stdlibMCEnv, loader) in
     match includeFileExn "." "treeppl::lib/standard.tppl" loader with (stdlibTPPLEnv, loader) in
-    let fileEnv = mergeSymEnv stdlibMCEnv.env stdlibTPPLEnv.env in
+    let fileEnv = stdlibTPPLEnv.env in
     -- Compiler libraries (these should *not* be in scope in the program)
     match includeFileExn "." "stdlib::ext/dist-ext.mc" loader with (distEnv, loader) in
     match includeFileExn "." "stdlib::ext/math-ext.mc" loader with (mathEnv, loader) in
@@ -1025,7 +1010,6 @@ lang TreePPLThings = TreePPLAst + TreePPLCompile
       , printJsonLn = _getVarExn "printJsonLn" jsonEnv
       , some = _getConExn "Some" optionEnv
       , matrixMul = _getVarExn "matMulExn" matrixEnv
-      , matrixPow = _getVarExn "mtxPow" stdlibMCEnv
       , matrixAdd = _getVarExn "matAddExn" matrixEnv
       , matrixMulFloat = _getVarExn "matScale" matrixEnv
       , repeat = _getVarExn "repeat" commonEnv
@@ -1046,7 +1030,7 @@ lang TreePPLThings = TreePPLAst + TreePPLCompile
 
     -- 3. Model invocations.
     let work = lam loader. lam decl.
-      match compileModelInvocation context hook.mkInferenceMethod loader decl with Some (loader, invocation) then
+      match compileModelInvocation context hook.mkInferenceMethod loader fileEnv decl with Some (loader, fileEnv, invocation) then
         let decl = DeclLet
           { body = invocation
           , ident = nameSym ""

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -17,6 +17,7 @@ include "mexpr/generate-json-serializers.mc"
 include "mexpr/utils.mc"
 include "mexpr/duplicate-code-elimination.mc"
 include "mexpr/generate-utest.mc"
+include "mexpr/uncurried.mc"
 include "ocaml/mcore.mc"
 include "ocaml/compile.mc"
 
@@ -44,6 +45,8 @@ lang TreePPLCompile
   + FloatAst + Resample + GenerateJsonSerializers + MExprEliminateDuplicateCode
   + MCoreLoader + JsonSerializationLoader
   + ProjMatchAst + TreePPLOperators
+  + TyVarOrConAst
+  + UncurriedAst
 
   -- a type with useful information passed down from compile
   type TpplCompileContext = {
@@ -69,11 +72,19 @@ lang TreePPLCompile
 
   sem compileTpplTypeDecl : DeclTppl -> [Decl]
   sem compileTpplTypeDecl =
-  | TypeDeclTppl x ->
+  | TypeDeclTppl (x & {constructor = Some c, alias = None _}) ->
     [ DeclType
-      { ident = x.name.v
-      , params = []
+      { ident = c.name.v
+      , params = map (lam x. x.v) c.params
       , tyIdent = tyvariant_ []
+      , info = x.info
+      }
+    ]
+  | TypeDeclTppl (x & {alias = Some a, constructor = None _}) ->
+    [ DeclType
+      { ident = a.name.v
+      , params = map (lam x. x.v) a.params
+      , tyIdent = compileTypeTppl a.ty
       , info = x.info
       }
     ]
@@ -81,82 +92,68 @@ lang TreePPLCompile
 
   sem compileTpplConDecl : DeclTppl -> [Decl]
   sem compileTpplConDecl =
-  | TypeDeclTppl x ->
+  | TypeDeclTppl (x & {constructor = Some c}) ->
     let f = lam constr.
       match constr with TypeCon constr in DeclConDef
       { ident = constr.name.v
       , tyIdent =
         let f = lam field. (field.name.v, compileTypeTppl field.ty) in
         let lhs = tyrecord_ (map f constr.fields) in
-        let rhs = ntycon_ x.name.v in
+        let rhs = ntycon_ c.name.v in
         tyarrow_ lhs rhs
       , info = constr.name.i
       } in
-    map f x.cons
+    map f c.cons
   | _ -> []
 
   sem compileTpplFunction: TpplCompileContext -> DeclTppl -> [RecLetBinding]
   sem compileTpplFunction (context: TpplCompileContext) =
   | FunDeclTppl f ->
+    let positional =
+      let g = lam x.
+        { ident = x.name.v
+        , tyAnnot = compileTypeTppl x.ty
+        , tyParam = tyunknown_
+        , info = x.name.i
+        } in
+      map g f.args in
+    let ret = optionMapOr tyunit_ compileTypeTppl f.returnTy in
     let body = foldr (lam f. lam e. f e)
       (withInfo f.info unit_)
-    (concat (map compileFunArg f.args) (map (compileStmtTppl context) f.body))
-    in
-    let argTypes = if null f.args
-      then [tyint_] -- nullary functions are ints
-      else map (lam a. compileTypeTppl a.ty) f.args in
-    let returnType = match f.returnTy with Some ty
-      then compileTypeTppl ty
-      else tyunknown_
-    in
-    let mType = foldr tyarrow_ returnType argTypes in
-    [{
-      ident = f.name.v,
-      tyBody = tyunknown_,
-      tyAnnot = tyWithInfo f.name.i mType,
-      body = if null f.args then
-        -- vsenderov 2023-08-04 Taking care of nullary functions by wrapping them in a lambda
-        printError (join [ "NOTE: Zero-argument function, `"
-                         , f.name.v.0
-                         , "`, converted to Int. "
-                         , "Potential type errors might refer to Int type."
-                         , "\n"
-                         ]);
-        flushStderr () ;
-        TmLam {
-          ident =  nameNoSym "_",
-          tyAnnot = TyInt { info = f.info },
-          tyParam = tyunknown_,
-          body = body,
-          ty = tyunknown_,
-          info = f.info
-        } else
-          body,
-      info = f.info
-    }]
+      (map (compileStmtTppl context) f.body) in
+    let function = TmUncurriedLam
+      { positional = positional
+      , body = body
+      , info = f.info
+      , ty = tyunknown_
+      } in
+    let fullTy = TyUncurriedArrow
+      { positional = map (lam x. x.tyAnnot) positional
+      , ret = ret
+      , info = f.info
+      } in
+    let fullTy = foldr (lam p. lam ty. ntyall_ p.v ty) fullTy f.tyParams in
+    [ { ident = f.name.v
+      , tyBody = tyunknown_
+      , tyAnnot = fullTy
+      , body = function
+      , info = f.info
+      }
+    ]
   | TypeDeclTppl _ -> []
-
-  sem compileFunArg: {name:{v:Name, i:Info}, ty:TypeTppl} -> (Expr -> Expr)
-
-  sem compileFunArg =
-  | arg ->
-    lam cont.
-    TmLam {
-      ident = arg.name.v,
-      tyAnnot = compileTypeTppl arg.ty,
-      tyParam = tyunknown_,
-      body = cont,
-      ty = tyunknown_,
-      info = arg.name.i
-    }
 
   sem compileTypeTppl: TypeTppl -> Type
 
   sem compileTypeTppl =
-  | TypeUsageTypeTppl x -> TyCon {
-      data = tyunknown_,
+  | NamedTypeTppl x -> TyVarOrCon {
       ident = x.name.v,
       info = x.name.i
+    }
+
+  | FunTypeTppl x -> TyUncurriedArrow
+    { positional = map compileTypeTppl x.params
+    , ret = compileTypeTppl x.ret
+    , info = x.info
     }
 
   | AtomicRealTypeTppl x -> TyFloat {
@@ -232,9 +229,13 @@ lang TreePPLCompile
       -- Either apply to 0 (if nullary model function) or each
       -- parameter in sequence
       let f = withInfo modelInfo (nvar_ x.name.v) in
-      if null x.args
-      then app_ f (int_ 0)
-      else foldl (lam l. lam p. app_ l (recordproj_ (nameGetStr p.0) (nvar_ parsedName))) f params in
+      let positional = map (lam p. recordproj_ (nameGetStr p.0) (nvar_ parsedName)) params in
+      TmUncurriedApp
+        { f = f
+        , positional = positional
+        , info = NoInfo ()
+        , ty = tyunknown_
+        } in
 
       let inferCode = appf2_ (nvar_ context.repeat)
         (ulam_ ""
@@ -422,15 +423,27 @@ lang TreePPLCompile
   sem compileExprTppl (context: TpplCompileContext) =
 
   | AnonFunExprTppl x ->
-    let args = if null x.args
-      then [(nameNoSym "", tyint_)]
-      else map (lam a. (a.name.v, compileTypeTppl a.ty)) x.args in
+    -- TODO(vipa, 2025-06-05): Ascribe a return type as well
+    let mkArg = lam a.
+      { ident = a.name.v
+      , tyAnnot = compileTypeTppl a.ty
+      , tyParam = tyunknown_
+      , info = a.name.i
+      } in
+    let positional = map mkArg x.args in
     let body = foldr (lam f. lam e. f e)
       (withInfo x.info unit_)
       (map (compileStmtTppl context) x.stmts) in
-    let wrap = lam pair. lam body.
-      withInfo x.info (nlam_ pair.0 pair.1 body) in
-    foldr wrap body args
+    let retTy = optionMapOr tyunit_ compileTypeTppl x.retTy in
+    let fun = TmUncurriedLam
+      { positional = positional
+      , body =
+        let x = nameSym "x" in
+        bind_ (nlet_ x retTy body) (nvar_ x)
+      , info = x.info
+      , ty = tyunknown_
+      } in
+    fun
 
   | ProjectionExprTppl x ->
     TmProjMatch {
@@ -440,26 +453,12 @@ lang TreePPLCompile
       ty = tyunknown_
     }
 
-  | FunCallExprTppl x ->
-    let f = compileExprTppl context x.f in
-    let app = lam f. lam arg.
-      TmApp {
-        info = x.info,
-        lhs = f,
-        rhs = compileExprTppl context arg,
-        ty = tyunknown_
-      } in
-    -- (vsenderov, 2023-08-04): If we are calling a nullary function,
-    -- in reailty the function is a function of int
-    if null x.args then
-      TmApp {
-        info = x.info,
-        lhs = f,
-        rhs = int_ 0,
-        ty = tyunknown_
-      }
-    else
-      foldl app f x.args
+  | FunCallExprTppl x -> TmUncurriedApp
+    { f = compileExprTppl context x.f
+    , positional = map (compileExprTppl context) x.args
+    , info = x.info
+    , ty = tyunknown_
+    }
 
   | BernoulliExprTppl d ->
     TmDist {
@@ -960,14 +959,17 @@ end
 
 lang TreePPLThings = TreePPLAst + TreePPLCompile
   + ProjMatchTypeCheck + ProjMatchPprint + MExprAst
+  + TyVarOrConSym
   + MExprGenerateEq
   + OverloadedOpTypeCheck
   + OverloadedOpPrettyPrint
   + TransformDist + CPPLLoader
   + ProjMatchToJson
   + JsonSerializationLoader
+  + DPrintViaPprintLoader + MExprGeneratePprint + GeneratePprintMissingCase
   + TreePPLOperators
-  + StripUtestLoader
+  + StripUtestLoader + PprintUnifyErrorNumArguments + UncurriedTypeCheck + SymUncurried + UncurriedPrettyPrint + LowerUncurryLoader
+  + UnifyUncurriedMixed
   + MExprLowerNestedPatterns + MCoreCompileLang
   + PhaseStats
   + BPFCompilerPicker + APFCompilerPicker + ImportanceCompilerPicker
@@ -1073,6 +1075,8 @@ lang TreePPLThings = TreePPLAst + TreePPLCompile
     let extArrOfSeq = app_
       (nvar_ (_getVarExn "extArrOfSeq" arrEnv))
       (nvar_ (_getVarExn "extArrKindFloat64" arrEnv)) in
+
+    -- NOTE(vipa, 2025-04-30): Json serialization
     let ser = ulam_ "serElem" (ulam_ "seq"
       (nconapp_ jsonArrName
         (map_ (var_ "serElem") (extArrToSeq_ (var_ "seq"))))) in
@@ -1080,7 +1084,9 @@ lang TreePPLThings = TreePPLAst + TreePPLCompile
       (match_ (var_ "json") (npcon_ jsonArrName (pvar_ "arr"))
         (optionMap_ extArrOfSeq (optionMapM_ (var_ "deserElem") (var_ "arr")))
         (nconapp_ (_getConExn "None" basicEnv) unit_))) in
-    registerCustomJsonSerializer extArrName {serializer = ser, deserializer = deser} loader
+    let loader = registerCustomJsonSerializer extArrName {serializer = ser, deserializer = deser} loader in
+
+    loader
 end
 
 type TpplFrontendOptions =
@@ -1121,8 +1127,10 @@ let compileTpplToExecutable = lam frontend. lam transformations. lam mkInference
   let loader = enableEqGeneration loader in
   let loader = enableDesugar loader in
   let loader = enableJsonSerialization loader in
+  let loader = enableDPrintViaPprint loader in
   let loader = registerMatrixFunctions loader in
   let loader = addHook loader (TreePPLHook {mkInferenceMethod = mkInferenceMethod}) in
+  let loader = addHook loader (LowerUncurryHook ()) in
   endPhaseStatsExpr log "mk-cppl-loader" unit_;
   let loader = (includeFileExn "." frontend.input loader).1 in
   endPhaseStatsExpr log "include-file" unit_;

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -176,8 +176,6 @@ prod left MatrixAdd: ExprTppl = left:ExprTppl "+@" right:ExprTppl
 prod left MatrixLeftScalarMul: ExprTppl = left:ExprTppl "$*" right:ExprTppl  -- owl standard (I think)
 prod left MatrixRightScalarMul: ExprTppl = left:ExprTppl "*$" right:ExprTppl  --
 
-prod left MatrixPower: ExprTppl = left:ExprTppl "^$" right:ExprTppl -- imagined but analogous to *$
-
 
   -- because the right has to be an integer not another matrix
 

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -73,16 +73,9 @@ prod DeclSequence: FileTppl =
   ("import" imports:String)*
   decls:DeclTppl+
 
-/-
-Type usage
-For now the type is only an Uppercase identifier, but in may
-be something else in the future (like with type parameters, etc.)
-Real
-Real[]
-Int[10]
--/
-prod TypeUsage: TypeTppl = name:UName
+prod Named: TypeTppl = name:UName
 prod TypeAppOrSequence: TypeTppl = ty:TypeTppl "[" (args:TypeTppl ("," args:TypeTppl)*)? "]"
+prod FunTypeTppl: TypeTppl = "Function" "(" (params:TypeTppl ("," params:TypeTppl)*)? ")" "=>" ret:TypeTppl
 
 prod AtomicReal: TypeTppl = "Real"
 prod AtomicBool: TypeTppl = "Bool"
@@ -97,8 +90,9 @@ optional return type, and the body is given in { }. It consists of statements.
 -/
 prod Fun: DeclTppl =
   model:"model"? "function" name:LName
+  ("[" tyParams:UName ("," tyParams:UName)* "]")?
   "(" (args:{name:LName ":" ty:TypeTppl} args:{"," name:LName ":" ty:TypeTppl}*)? ")"
-  (":" returnTy:TypeTppl)?
+  ("=>" returnTy:TypeTppl)?
   "{" body:StmtTppl* "}"
 
 /-
@@ -110,11 +104,20 @@ prod TypeCon: Con =
 
 /- Here is how you declare a type -/
 prod Type: DeclTppl =
-  "type" name:UName "="
-  ("|"? cons:Con)
-  ("|" cons:Con)*
-
-
+  "type"
+  ( constructor:
+    { name:UName
+      ("[" params:UName ("," params:UName)* "]")?
+      "="
+      ("|"? cons:Con)
+      ("|" cons:Con)*
+    }
+  | alias:
+    { "alias" name:UName
+      ("[" params:UName ("," params:UName)* "]")?
+      "=" ty:TypeTppl
+    }
+  )
 
 
 /-
@@ -151,7 +154,7 @@ prod left Less: ExprTppl = left:ExprTppl "<" right:ExprTppl
 prod left Greater: ExprTppl = left:ExprTppl ">" right:ExprTppl
 prod left LessEq: ExprTppl = left:ExprTppl "<=" right:ExprTppl
 prod left GreaterEq: ExprTppl = left:ExprTppl ">=" right:ExprTppl
-prod left Equal: ExprTppl = left:ExprTppl "==" right:ExprTppl -- currently implemented as floats which doesn't make much sense
+prod left Equal: ExprTppl = left:ExprTppl "==" right:ExprTppl
 prod left Unequal: ExprTppl = left:ExprTppl "!=" right:ExprTppl
 -- Boolean operators
 infix left And: ExprTppl = "&&"
@@ -182,7 +185,7 @@ prod left MatrixPower: ExprTppl = left:ExprTppl "^$" right:ExprTppl -- imagined 
 
 prod AnonFun: ExprTppl = "function"
   "(" (args:{name:LName ":" ty:TypeTppl} args:{"," name:LName ":" ty:TypeTppl}*)? ")"
-  "{" stmts:StmtTppl* "}"
+  ("=>" retTy:TypeTppl)? "{" stmts:StmtTppl* "}"
 
 -- Function call as expression
 prod FunCall: ExprTppl = f:ExprTppl "(" (args:ExprTppl ("," args:ExprTppl)*)? ")"
@@ -196,6 +199,11 @@ precedence {
   Add Sub;
   ~Less Greater LessEq GreaterEq Equal Unequal;
   ~And Or;
+}
+
+precedence {
+  Projection FunCall Subscript;
+  ~MatrixMul MatrixAdd MatrixLeftScalarMul MatrixRightScalarMul;
 }
 
 -- Built-in distro keywords
@@ -226,10 +234,13 @@ prod Assign: StmtTppl = "let" var:LName (":" ty:TypeTppl)? "=" val:ExprTppl ";"
 --prod Observe: StmtTppl = "observe" value:ExprTppl "~" distribution:UName "(" (args:ExprTppl ("," args:ExprTppl)*)? ")"
 prod Observe: StmtTppl = "observe" value:ExprTppl "~" dist:ExprTppl ";"
 prod Resample: StmtTppl = "resample" ";"
-prod If: StmtTppl = "if" condition:ExprTppl "{" ifTrueStmts:StmtTppl* "}" ("else" "{" ifFalseStmts:StmtTppl* "}")?
+prod If: StmtTppl =
+  "if" condition:ExprTppl
+  "{" ifTrueStmts:StmtTppl* "}"
+  ("else" "{" ifFalseStmts:StmtTppl* "}")?
 prod Weight: StmtTppl = "weight" value:ExprTppl ";"
 prod LogWeight: StmtTppl = "logWeight" value:ExprTppl ";"
 prod ForLoop: StmtTppl = "for" iterator:LName "in" range:ExprTppl "{" forStmts:StmtTppl* "}"
 prod Return: StmtTppl = "return" return:ExprTppl? ";"
 
-prod Print: StmtTppl = "dump" "(" printable:ExprTppl ")" ";"
+prod Print: StmtTppl = "debug" "(" printable:ExprTppl ")" ";"


### PR DESCRIPTION
This PR was initially intended to just make functions uncurried, but it kind of snowballed, because that means that we can't just call MCore functions as though they're TreePPL functions any more, which means we need to change the way our standard library is defined.

## No more automatic currying
```
function addi(a : Int, b : Int) : Int { return a + b; }

function example() {
  addi(1);       // Compile error, wrong number of arguments
  addi(1, 2);    // OK
  addi(1, 2, 3); // Compile error, wrong number of arguments

  // You need to explicitly engage with currying if you run into it
  functionImportedFromMCore(arg1)(arg2)(arg3);  // OK
  functionImportedFromMCore(arg1, arg2, arg3);  // Not ok
}
```

## Polymorphic function declarations:
Polymorphic variables in square brackets. We could also be implicitly polymorphic over type variables, if we wanted to (which would mean that `[a, b, c]` wouldn't be needed, but in return we won't catch unbound type variables in the signature that are likely typos).
```
function[a, b, c](x : a, y : b[], z : Matrix[c]) : c { ... }
        ---------
```

## Function types
I don't like this syntax, the double `:` feels clunky, and `function` feels heavy. I'm using this syntax for now since it's the most obvious given function declarations, and it works with our parsing strategy.
```
function sapply[a, b](s : a[], f : function(a):b) : b[] { ... }
                                   -------------
```
Relevant: uncurried function types are currently printed like `(a, b, c) => ret`, but unfortunately this doesn't fit with LL1, so we can't use that syntax right now.

## Type aliases
```
type alias Message = Matrix[Real][]
```

## `dump` and printing
I'm changing the `dump(x);` syntax to instead be `debug(x);`, and making it use the new pretty-printing machinery so it prints something readable. This naming feels nicer to me. I'm also thinking of removing `print` and `printLn`.

## Changes to standard library and built-in operators
- Removed `^$`, use `mtxPow` instead
- Removed `addi`, `eqi`, `geqi`, `gti`, `muli`, `neqi`, `subf`, `subi`, use operators instead
	- It's annoying to pass these as functions now (`zipWith(function(a : Int, b : Int) { return a + b; }, as, bs)` vs `zipWith(addi, as, bs)`), but I would argue that should be fixed with some other feature.
- Added `foldi`
	- Note: this is `foldli` underneath, we don't expose `foldr` or `foldri` (the latter doesn't exist in mcore either)