### PR TITLE
Expose the builtin Dist type

### DIFF
--- a/models/lang/blub.tppl
+++ b/models/lang/blub.tppl
@@ -97,6 +97,11 @@ model function blub(n: Int, pi: Real, trump: Bool, coinflips: Bool[], text: Stri
   printLn(int2string(add2and3(1, 2)));
   printLn(int2string(add2and3(6, 2)));
 
+  printLn("Dist type");
+  let d : Dist[Bool] = Bernoulli(0.5);
+  assume f ~ d;
+  printLn(bool2string(f));
+
   for i in 1 to 10 {
     if i > 5.0 {
       print("\n");

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -167,6 +167,13 @@ lang TreePPLCompile
       info = x.info
     }
 
+  | AtomicDistTypeTppl x ->
+    errorSingle [x.info] "The Dist type needs exactly one type argument."
+  | TypeAppOrSequenceTypeTppl (x & {ty = AtomicDistTypeTppl _, args = [arg]}) -> TyDist {
+      info = x.info,
+      ty = compileTypeTppl arg
+    }
+
   | TypeAppOrSequenceTypeTppl (x & {args = []}) -> TySeq {
     info = x.info,
     ty = compileTypeTppl x.ty

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -80,6 +80,7 @@ prod FunTypeTppl: TypeTppl = "Function" "(" (params:TypeTppl ("," params:TypeTpp
 prod AtomicReal: TypeTppl = "Real"
 prod AtomicBool: TypeTppl = "Bool"
 prod AtomicInt: TypeTppl = "Int"
+prod AtomicDist: TypeTppl = "Dist"
 prod TpplStr: TypeTppl = "String"
 prod Nothing: TypeTppl = "(" ")"
 


### PR DESCRIPTION
This PR exposes the `Dist` type present in coreppl, which is used in `assume`s and `observe`s. This is primarily useful to express drift kernels as reusable functions, since such functions would have to mention the type of distribution they return.