### PR TITLE
Make `debug` handle more arguments

### DIFF
--- a/models/lang/blub.tppl
+++ b/models/lang/blub.tppl
@@ -32,80 +32,76 @@ model function blub(n: Int, pi: Real, trump: Bool, coinflips: Bool[], text: Stri
   printLn(concat("Trump was elected: ", bool2string(trump)));
 
   let testVec = [1, 2];
-  printLn(int2string(testVec[1]));
-  printLn(int2string(testVec[2]));
+  debug("testVec (", testVec, ") contains ", testVec[1], " and ", testVec[2]);
 
   let coinFlipStr = sapply(coinflips, bool2string);
-  printLn(concat("The length of the vector is ", int2string(length(coinflips))));
-  let y = paste0(coinFlipStr); //cannot use concat on more than two argumnets
-  printLn(y);
+  debug("The length of the vector is ", length(coinflips), " it contains ", coinFlipStr);
 
-  printLn("Arithmetic");
-  printLn(real2string(2.0 + 3.0));
-  printLn(int2string(2 + 3));
-  printLn(real2string(2.0 * 3.0));
-  printLn(int2string(2 * 3));
-  printLn(real2string(2.0 / 3.0));
-  printLn(int2string(2 / 3));
-  printLn(real2string(2.0 - 3.0));
-  printLn(int2string(2 - 3));
-  printLn(real2string(2.0 ^ 3.0));
+  printLn("\nArithmetic");
+  debug("2.0 + 3.0 = ", 2.0 + 3.0);
+  debug("2 + 3 = ", 2 + 3);
+  debug("2.0 * 3.0 = ", 2.0 * 3.0);
+  debug("2 * 3 = ", 2 * 3);
+  debug("2.0 / 3.0 = ", 2.0 / 3.0);
+  debug("2 / 3 = ", 2 / 3);
+  debug("2.0 - 3.0 = ", 2.0 - 3.0);
+  debug("2 - 3 = ", 2 - 3);
+  debug("2.0 ^ 3.0 = ", 2.0 ^ 3.0);
 
-  printLn("Lt");
-  printLn(bool2string(2.0 < 3.0));
-  printLn(bool2string(2.0 <= 3.0));
-  printLn(bool2string(2 < 3.0));
-  printLn(bool2string(2 <= 3.0));
-  printLn(bool2string(2.0 < 3));
-  printLn(bool2string(2.0 <= 3));
-  printLn(bool2string(2 < 3));
-  printLn(bool2string(2 <= 3));
-  printLn("Eq");
-  printLn(bool2string(2.0 == 3.0));
-  printLn(bool2string(2 == 3));
-  printLn("Gt");
-  printLn(bool2string(2.0 >= 3.0));
-  printLn(bool2string(2.0 > 3.0));
-  printLn(bool2string(2 >= 3.0));
-  printLn(bool2string(2 > 3.0));
-  printLn(bool2string(2.0 >= 3));
-  printLn(bool2string(2.0 > 3));
-  printLn(bool2string(2 >= 3));
-  printLn(bool2string(2 > 3));
+  printLn("\nComparators");
+  debug("2.0 < 3.0 = ", 2.0 < 3.0);
+  debug("2.0 <= 3.0 = ", 2.0 <= 3.0);
+  debug("2 < 3.0 = ", 2 < 3.0);
+  debug("2 <= 3.0 = ", 2 <= 3.0);
+  debug("2.0 < 3 = ", 2.0 < 3);
+  debug("2.0 <= 3 = ", 2.0 <= 3);
+  debug("2 < 3 = ", 2 < 3);
+  debug("2 <= 3 = ", 2 <= 3);
+  debug("Eq");
+  debug("2.0 == 3.0 = ", 2.0 == 3.0);
+  debug("2 == 3 = ", 2 == 3);
+  debug("Gt");
+  debug("2.0 >= 3.0 = ", 2.0 >= 3.0);
+  debug("2.0 > 3.0 = ", 2.0 > 3.0);
+  debug("2 >= 3.0 = ", 2 >= 3.0);
+  debug("2 > 3.0 = ", 2 > 3.0);
+  debug("2.0 >= 3 = ", 2.0 >= 3);
+  debug("2.0 > 3 = ", 2.0 > 3);
+  debug("2 >= 3 = ", 2 >= 3);
+  debug("2 > 3 = ", 2 > 3);
 
-  printLn("And");
-  printLn(bool2string(true && true));
-  printLn(bool2string(true && false));
-  printLn(bool2string(false && true));
-  printLn(bool2string(false && false));
+  printLn("\nBoolean operators");
+  debug("true && true = ", true && true);
+  debug("true && false = ", true && false);
+  debug("false && true = ", false && true);
+  debug("false && false = ", false && false);
 
-  printLn("Or");
-  printLn(bool2string(true || true));
-  printLn(bool2string(true || false));
-  printLn(bool2string(false || true));
-  printLn(bool2string(false || false));
+  debug("true || true = ", true || true);
+  debug("true || false = ", true || false);
+  debug("false || true = ", false || true);
+  debug("false || false = ", false || false);
 
-  printLn("Not");
-  printLn(bool2string(!false));
-  printLn(bool2string(!true));
+  debug("!false = ", !false);
+  debug("!true = ", !true);
 
+  printLn("\nPartial application");
   let add2 = example(_, 2);
-  printLn(int2string(add2(1)));
-  printLn(int2string(add2(6)));
+  debug("add2(1) = ", add2(1));
+  debug("add2(6) = ", add2(6));
 
   let add2and3 = example3(_, _, 3);
-  printLn(int2string(add2and3(1, 2)));
-  printLn(int2string(add2and3(6, 2)));
+  debug("add2and3(1, 2) = ", add2and3(1, 2));
+  debug("add2and3(6, 2) = ", add2and3(6, 2));
 
-  printLn("Dist type");
+  printLn("\nDist type");
   let d : Dist[Bool] = Bernoulli(0.5);
   assume f ~ d;
-  printLn(bool2string(f));
+  debug("Drew random value: ", f);
 
-  printLn("Float2Int");
-  printLn(int2string(floor(0.5)));
-  printLn(int2string(ceil(0.5)));
-  printLn(int2string(round(0.5)));
+  printLn("\nFloat2Int");
+  debug("floor(0.5) = ", floor(0.5));
+  debug("ceil(0.5) = ", ceil(0.5));
+  debug("round(0.5) = ", round(0.5));
 
   for i in 1 to 10 {
     if i > 5.0 {

--- a/src/treeppl-to-coreppl/compile.mc
+++ b/src/treeppl-to-coreppl/compile.mc
@@ -469,7 +469,13 @@ lang TreePPLCompile
     StmtNoCont (optionMapOr (withInfo r.info unit_) (compileExprTppl context) r.return)
 
   | PrintStmtTppl x ->
-    StmtSimple ([], Some (isemi_ (dprint_ (compileExprTppl context x.printable)) (flushStdout_ unit_)))
+    let processTerm : Bool -> ExprTppl -> (Bool, Expr) = lam maybeInsertSpace. lam expr.
+      match expr with TpplStringExprTppl x then (false, printError_ (str_ x.val.v)) else
+      let p = dprint_ (compileExprTppl context expr) in
+      (true, if maybeInsertSpace then isemi_ (printError_ (str_ " ")) p else p) in
+    let final = isemi_ (printError_ (str_ "\n")) (flushStderr_ unit_) in
+    let print = foldr isemi_ final (mapAccumL processTerm false x.printable).1 in
+    StmtSimple ([], Some print)
 
   sem compileExprTppl: TpplCompileContext -> ExprTppl -> Expr
 

--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -246,4 +246,4 @@ prod LogWeight: StmtTppl = "logWeight" value:ExprTppl ";"
 prod ForLoop: StmtTppl = "for" iterator:LName "in" range:ExprTppl "{" forStmts:StmtTppl* "}"
 prod Return: StmtTppl = "return" return:ExprTppl? ";"
 
-prod Print: StmtTppl = "debug" "(" printable:ExprTppl ")" ";"
+prod Print: StmtTppl = "debug" "(" (printable:ExprTppl ("," printable:ExprTppl)*)? ")" ";"


### PR DESCRIPTION
This PR changes the `debug` statement to be more intelligent. It can now take any number of arguments and print all of them, followed by a newline. Additionally:

- If an argument is a literal string it will be printed directly, otherwise it will be pretty-printed. For example, `debug("foo\nbar");` will print the line `foo` followed by the line `bar`, while `let ex = "foo\nbar"; debug(ex);` will print the line `"foo\nbar"`.
- If two adjacent arguments are not literal strings, then a space will be inserted. For example, `debug(1, 2);` will print the line `1 2`, not `12`.

Example:
```
let text = "foo\nbar";
debug("Example: ", 42, 1.0, " and ", text);
// => Example: 42 1.0 and "foo\nbar" 
```

If you want to do your own formatting you can still use `print` and `printLn` as before (with explicit conversions).

---

This moves `debug` towards being a more fancy special thing in the language. That gives some options that we may or may not want to consider:
- We could have some more specialized syntax (as an aside, we don't have a good way of parsing string interpolation atm, so that particular option would have to wait).
- We could print more automatically generated information, e.g., line number of the `debug` itself, with or without printing the line itself.
- We could have flags that turn on/off these statements.