### PR TITLE
Add description of HRM in model library

### DIFF
--- a/models/host-repertoire-evolution/README.md
+++ b/models/host-repertoire-evolution/README.md
@@ -4,5 +4,13 @@ title: Host-repertoire model
 sidebar_label: Host-repertoire model
 ---
 
-<meta http-equiv="refresh" content="0; url=https://treeppl.org/treepplr/articles/hostrep-example.html" />
-If you are not redirected automatically to the *treepplr* documentation, follow this [link](https://treeppl.org/treepplr/articles/hostrep-example.html).
+# Host repertoire evolution
+
+  - **Model files:** `models/host-repertoire-evolution/flat-root-prior-HRM.tppl` and `models/host-repertoire-evolution/subroot-HRM.tppl`. 
+
+  - **Example input data:** `models/host-repertoire-evolution/testdata_flat-root-prior-HRM.json` and `models/host-repertoire-evolution/testdata_subroot-HRM.json`.
+
+  - **Brief info:** The `subroot` model considers that there is a branch subtending the root of the symbiont tree, which allows the host gain/loss process to reach stationarity before diversification of the symbiont clade starts. This version of the model is identical to the model implemented in RevBayes. The `flat-root-prior` model considers that the symbiont tree - and thus the host gain/loss process - starts at the root.
+
+  - **Reference:**
+  Braga, M. P., Landis, M. J., Nylin, S., Janz, N., & Ronquist, F. (2020). Bayesian inference of ancestral host–parasite interactions under a phylogenetic model of host repertoire evolution. Systematic biology, 69(6), 1149-1162. https://doi.org/10.1093/sysbio/syaa019


### PR DESCRIPTION
Follow the same standard as the other models instead of directing to the treepplr vignette.