### PR TITLE
External log gamma

### DIFF
--- a/lib/auto-import/distribution.tppl
+++ b/lib/auto-import/distribution.tppl
@@ -107,7 +107,7 @@ function drawGammaExponential(gdist: GammaDist, multiplier: Real) => GammaExpDra
 function negbinomialLogPMF(x: Int, r: Real, p: Real) => Real {
 
     let k = int2real(x);
-    return lnGamma(k+r-1.0) - lnGamma(r-1.0) - lnGamma(k) + k*log(1.0-p) + r*log(p);
+    return logGamma(k+r-1.0) - logGamma(r-1.0) - logGamma(k) + k*log(1.0-p) + r*log(p);
 }
 
 function negbinomialRv(r: Real, p: Real) => Int {

--- a/lib/auto-import/math.mc
+++ b/lib/auto-import/math.mc
@@ -9,5 +9,7 @@ let mathLog = log
 let mathSqrt = sqrt
 let mathModi = modi
 
+let mathLogGamma = logGamma
+
 let mathMini = mini
 let mathMaxi = maxi

--- a/lib/auto-import/math.tppl
+++ b/lib/auto-import/math.tppl
@@ -70,47 +70,6 @@ function logFactorial(n: Real) => Real {
   return log(n) + logFactorial(n - 1.0);
 }
 
-// TODO: Implement the approx in full (requires fabs, sin)
-// TODO: Should PI be defined as global constant?
-function lnGamma(z: Real) => Real {
-
-    let pi = 3.14159265358979;
-    let lanczos_g = 7.0;
-    let lanczos_n = 9;
-    let lanczos_c = [
-        0.99999999999980993,
-        676.5203681218851,
-       -1259.1392167224028,
-        771.32342877765313,
-       -176.61502916214059,
-        12.507343278686905,
-       -0.13857109526572012,
-        9.9843695780195716e-6,
-        1.5056327351493116e-7];
-
-    /* ---- Poles at non‑positive integers -------------------------------- */
-    // if (z <= 0.0) && (fabs(z - round(z)) < 1e-12) { return -Inf; }
-    if (z <= 0.0) {
-        return -1e-12;    // This case should not occur in the model
-    }
-
-    /* ---- Use reflection for negative arguments (z < 0.5) --------------- */
-    if (z < 0.5) {
-        /* Recursively evaluate lnGamma(1‑z) which lies in (0.5, ifty) */
-        // return log(pi) - log(sin(pi * z)) - lnGamma(1.0 - z);
-        return -1e-12; // This case should not occur in the model
-    }
-
-    /* ---- Shift the argument (Lanczos works with z‑1) ------------------- */
-    let zz = z - 1.0;
-    let x  = lanczos_c[1];             /* c1 */
-
-    for i in 2 to lanczos_n {
-        let x = x + lanczos_c[i] / (zz + Real(i-1));
-    }
-
-    let t = zz + lanczos_g + 0.5;
-
-    /* Final lnGamma formula */
-    return 0.5 * log(2.0 * pi) + (zz + 0.5) * log(t) - t + log(x);
+function logGamma(z: Real) => Real {
+  return mathLogGamma(z);
 }


### PR DESCRIPTION
Includes #153 until it is merged.

This PR replaces the manually written `lnGamma` with the already existing external `logGamma` (from `owl`).

---

## TreePPL Release Notes

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security
