### PR TITLE
Add proper uses of TmOpaque in matrix library

### DIFF
--- a/lib/auto-import/matrix.mc
+++ b/lib/auto-import/matrix.mc
@@ -1,6 +1,6 @@
 include "ext/mat-ext.mc"
 
-let _iterateni = lam bound. lam f.
+let _iterateni : all a. Int -> (Int -> a -> a) -> a -> a = lam bound. lam f.
   recursive let work = lam i. lam acc.
     if lti i bound
     then work (addi i 1) (f i acc)
@@ -15,22 +15,43 @@ let matNumRows : all x. Mat x -> Int = lam mtx. mtx.m
 let matNumCols : all x. Mat x -> Int = lam mtx. mtx.n
 let matNormalize = lam mtx.
   let sum = _iterateni (muli mtx.m mtx.n) (lam i. lam acc. addf acc (extArrGetExn mtx.arr i)) 0.0 in
-  let mtx = matCopy mtx in
-  repeati (lam i. extArrSetExn mtx.arr i (divf (extArrGetExn mtx.arr i) sum)) (muli mtx.m mtx.n);
-  mtx
+  tmOpaque (
+    let mtx = matCopy mtx in
+    let f = lam i. extArrSetExn mtx.arr i (divf (extArrGetExn mtx.arr i) sum) in
+    recursive let repeati : Int -> () = lam i.
+      if geqi i 0
+      then f i; repeati (subi i 1)
+      else () in
+    repeati (subi (muli mtx.m mtx.n) 1);
+    mtx
+  )
 let matGetRow : all a. Int -> Mat a -> Mat a = lam row. lam mtx.
-  let new = matMakeUninit (externalExtArrKind mtx.arr) 1 mtx.n in
-  let r = subi row 1 in
-  -- OPT(vipa, 2025-03-07): Working with individual cells is likely
-  -- inefficient
-  repeati (lam i. matSetExn new 0 i (matGetExn mtx r i)) mtx.n;
-  new
+  tmOpaque (
+    let new = matMakeUninit (externalExtArrKind mtx.arr) 1 mtx.n in
+    let r = subi row 1 in
+    -- OPT(vipa, 2025-03-07): Working with individual cells is likely
+    -- inefficient
+    let f = lam i. matSetExn new 0 i (matGetExn mtx r i) in
+    recursive let repeati : Int -> () = lam i.
+      if geqi i 0
+      then f i; repeati (subi i 1)
+      else () in
+    repeati (subi mtx.n 1);
+    new
+  )
 let matElemPow = lam mtx. lam f.
-  let mtx = matCopy mtx in
-  -- OPT(vipa, 2025-03-07): Working with individual cells is likely
-  -- inefficient
-  repeati (lam i. extArrSetExn mtx.arr i (pow (extArrGetExn mtx.arr i) f)) (muli mtx.m mtx.n);
-  mtx
+  tmOpaque (
+    let mtx = matCopy mtx in
+    -- OPT(vipa, 2025-03-07): Working with individual cells is likely
+    -- inefficient
+    let f = lam i. extArrSetExn mtx.arr i (pow (extArrGetExn mtx.arr i) f) in
+    recursive let repeati : Int -> () = lam i.
+      if geqi i 0
+      then f i; repeati (subi i 1)
+      else () in
+    repeati (subi (muli mtx.m mtx.n) 1);
+    mtx
+  )
 let matMean = lam t.
   -- OPT(vipa, 2025-03-07): Working with individual cells is likely
   -- inefficient
@@ -42,9 +63,39 @@ let matApplyToSeq : all a. all b. Mat a -> (a -> b) -> [b] = lam x. lam f.
 -- if we get the appropriate form of overloading we could make indexing (a[idxs])
 -- call the correct one of those later on
 let matRowCols = lam matrix. lam row. lam cols.
-  let r = subi row 1 in
-  let new = matMakeUninit (externalExtArrKind matrix.arr) 1 (length cols) in
-  -- OPT(vipa, 2025-03-07): Working with individual cells is likely
-  -- inefficient
-  iteri (lam i. lam c. matSetExn new 0 i (matGetExn matrix r (subi c 1))) cols;
-  new
+  tmOpaque (
+    let r = subi row 1 in
+    let new = matMakeUninit (externalExtArrKind matrix.arr) 1 (length cols) in
+    -- OPT(vipa, 2025-03-07): Working with individual cells is likely
+    -- inefficient
+    let f = lam i. lam c. matSetExn new 0 i (matGetExn matrix r (subi c 1)) in
+    let iteri = lam seq.
+      recursive let work = lam i. lam seq.
+        match seq with [s] ++ seq
+        then f i s; work (addi i 1) seq
+        else () in
+      work 0 seq in
+    iteri cols;
+    new
+  )
+
+let _mtxCreate = lam rows. lam cols. lam data.
+  matFromArrExn rows cols (tmOpaque (extArrOfSeq extArrKindFloat64 data))
+
+let _mtxCreateId = lam sideLength.
+  tmOpaque (
+    let mtx = matMake extArrKindFloat64 sideLength sideLength 0.0 in
+    let f = lam i. matSetExn mtx i i 1.0 in
+    recursive let repeati : Int -> () = lam i.
+      if geqi i 0
+      then f i; repeati (subi i 1)
+      else () in
+    repeati (subi sideLength 1);
+    mtx
+  )
+
+let _rvecCreate = lam cols. lam seq.
+  matFromArrExn 1 cols (tmOpaque (extArrOfSeq extArrKindFloat64 seq))
+
+let _cvecCreate = lam rows. lam seq.
+  matFromArrExn rows 1 (tmOpaque (extArrOfSeq extArrKindFloat64 seq))

--- a/lib/auto-import/matrix.tppl
+++ b/lib/auto-import/matrix.tppl
@@ -8,21 +8,19 @@ import "./debug.mc"
 type alias Matrix[X] = Mat[X]
 
 function mtxCreate(rows : Int, cols : Int, data : Real[]) => Matrix[Real] {
-  return matFromArrExn(rows)(cols)(extArrOfSeq(extArrKindFloat64)(data));
+  return _mtxCreate(rows)(cols)(data);
 }
 
 function mtxCreateId(sideLength : Int) => Matrix[Real] {
-  let mat = matMake(extArrKindFloat64)(sideLength)(sideLength)(0.0);
-  repeati(function(i : Int) {return matSetExn(mat)(i)(i)(1.0);})(sideLength);
-  return mat;
+  return _mtxCreateId(sideLength);
 }
 
 function rvecCreate(cols : Int, seq : Real[]) => Matrix[Real] {
-  return matFromArrExn(1)(cols)(extArrOfSeq(extArrKindFloat64)(seq));
+  return _rvecCreate(cols)(seq);
 }
 
 function cvecCreate(rows : Int, seq : Real[]) => Matrix[Real] {
-  return matFromArrExn(rows)(1)(extArrOfSeq(extArrKindFloat64)(seq));
+  return _cvecCreate(rows)(seq);
 }
 
 function dim[X](mtx : Matrix[X]) => Int[] {


### PR DESCRIPTION
Some matrix operations were defined with side-effects internally without being wrapped in `tmOpaque`, which can cause mis-compilation when using `mcmc-graph`. This PR fixes that.

---

Suggest bullets to add to [the changelog](https://treeppl.org/docs/changelog) below (under `###` headings), if any. A PR that has a user-visible change should have a bullet, even if it's, e.g., just a bugfix.

## TreePPL Release Notes

### Added

### Changed

### Deprecated

### Removed

### Fixed
- Matrix operations should no longer be compiled incorrectly when using `mcmc-graph`.

### Security
