### PR TITLE
Apf iterations control

### DIFF
--- a/lib/internal/runtime-flags.mc
+++ b/lib/internal/runtime-flags.mc
@@ -68,6 +68,15 @@ let _subsampleSize : Int -> OptParser Int = lam default.
   optOr opt (optPure default)
 let subsampleSize = _subsampleSize 1
 
+let _maxPropagations: Int -> OptParser Int = lam default.
+  let opt = optArg
+    { optArgDefInt with long = "max-propa"
+    , description = concat "The number of time smc-apf (at a specific resample step) will try to find a non-zero weight path for a particule. Default: " (int2string default)
+    , category = catRun
+    } in
+  optOr opt (optPure default)
+let maxPropagations = _maxPropagations 1000
+
 let _samplingPeriod : Int -> OptParser Int = lam default.
   let opt = optArg
     { optArgDefInt with long = "sampling-period"

--- a/lib/internal/runtime-flags.mc
+++ b/lib/internal/runtime-flags.mc
@@ -70,8 +70,8 @@ let subsampleSize = _subsampleSize 1
 
 let _maxPropagations: Int -> OptParser Int = lam default.
   let opt = optArg
-    { optArgDefInt with long = "max-propa"
-    , description = concat "The number of time smc-apf (at a specific resample step) will try to find a non-zero weight path for a particule. Default: " (int2string default)
+    { optArgDefInt with long = "max-propagations"
+    , description = concat "The maximum number of attempts tried by smc-apf (at a given resample step) to find a non-zero weighted path for a particle. Default: " (int2string default)
     , category = catRun
     } in
   optOr opt (optPure default)

--- a/src/tpplc.mc
+++ b/src/tpplc.mc
@@ -378,7 +378,7 @@ let isLwOptions : OptParser MkInferMethod =
   optMap2 (lam. lam x. x) (optOr method (optPure ())) res in
 
 let smcApfOptions : OptParser MkInferMethod =
-  let mk = lam particles. lam subsample. lam subsampleSize. lam resample. lam prune. lam cps. lam. lam loader.
+  let mk = lam particles. lam subsample. lam subsampleSize. lam maxPropagations. lam resample. lam prune. lam cps. lam. lam loader.
     match includeFileExn "." "treeppl::internal/runtime-flags.mc" loader with (flagEnv, loader) in
     let getOptParser : String -> Expr -> Expr = lam ident. lam default.
       app_ (nvar_ (_getVarExn ident flagEnv)) default in
@@ -386,6 +386,7 @@ let smcApfOptions : OptParser MkInferMethod =
       [ ("particles", getOptParser "_particles" (int_ particles))
       , ("subsample", getOptParser "_subsample" (bool_ subsample))
       , ("subsampleSize", getOptParser "_subsampleSize" (int_ subsampleSize))
+      , ("maxPropagations", getOptParser "_maxPropagations" (int_ maxPropagations))
       ] in
     match makeOptParser loader fields with (loader, optParser) in
     ( loader
@@ -393,6 +394,7 @@ let smcApfOptions : OptParser MkInferMethod =
         { particles = recordproj_ "particles" (nvar_ n)
         , subsample = recordproj_ "subsample" (nvar_ n)
         , subsampleSize = recordproj_ "subsampleSize" (nvar_ n)
+        , maxPropagations = recordproj_ "maxPropagations" (nvar_ n)
         , resample = resample
         , prune = prune
         , cps = cps
@@ -400,7 +402,7 @@ let smcApfOptions : OptParser MkInferMethod =
       , optParser = optParser
       }
     ) in
-  let res = optApply (optMap5 mk particles subsample subsampleSize _resample _prune) _cps in
+  let res = optApply (optApply (optMap5 mk particles subsample subsampleSize maxPropagations _resample) _prune) _cps in
   let method = optSpecificArg
     { optExactArg "smc-apf" with short = "m", long = "method"
     , description = "SMC using the alive particles filter"


### PR DESCRIPTION
Add maxPropagations variable, treeppl side of [PR 245](https://github.com/miking-lang/miking-dppl/pull/245/).

---

Suggest bullets to add to [the changelog](https://treeppl.org/docs/changelog) below (under `###` headings), if any. A PR that has a user-visible change should have a bullet, even if it's, e.g., just a bugfix.

## TreePPL Release Notes

### Added

- Add `--max-propagations INT` to limit `smc-apf` near infinite loop (see tpplc --help for more details)

### Changed

### Deprecated

### Removed

### Fixed

### Security
