### PR TITLE
new version for clads2 and bdd2 models

### DIFF
--- a/lib/models/diversification/bdd2.tppl
+++ b/lib/models/diversification/bdd2.tppl
@@ -5,6 +5,9 @@
 // mu is a constant fraction of lambda. This fraction is referred to as epsilon
 // in earlier work by us on ClaDS2.
 
+//import "treeppl::trees.tppl"
+//import "treeppl::math.tppl"
+
 
 // Types
 // -----
@@ -17,6 +20,13 @@ type Globals = Globals {
   logAlpha : Real,
   rho      : Real,
   deltaT   : Real
+}
+
+type ReturnType = ReturnType{
+    lambda:     Real, 
+    mu:         Real, 
+    logAlpha:   Real, 
+    sigma:      Real
 }
 
 // We use clock tree representation
@@ -69,6 +79,11 @@ function bddCase(timeSegment: Real, waitingTime: Real, deltaT: Real) => BDDCase 
     return (EndOfBranch{ timeSegment=timeSegment });
 }
 
+// Need for the alignment analysis of the compiler
+function waitTime(multiplier: Real, rate: Real) => Real {
+    assume waitingTime ~ Exponential(multiplier*rate);
+    return waitingTime;
+}
 
 // Model functions
 // ---------------
@@ -91,7 +106,7 @@ function numTrialsUntilMRCADetection(g: Globals, tRoot: Real, mMax: Int) => Int 
         return 1;    // We are detected, terminate!
     } else {
         // MRCA is not detected, continue recursion
-        return (1 + numTrialsUntilMRCADetection(g, tRoot, mMax-1));
+        return (1 + numTrialsUntilMRCADetection(g, tRoot, mMax-1)); 
     }
 }
 
@@ -113,8 +128,8 @@ function isDetected(g: Globals, multiplier: Real, tBegin: Real) => Bool {
     }
 
     // We always need to consider the possibility of an event
-    assume waitingTime ~ Exponential(multiplier*(g.lambda+g.mu));
-
+    let waitingTime = waitTime(multiplier, g.lambda+g.mu);
+ 
     // Find out BDD case and time frame we will be considering
     // Note that tEnd is 0, so tSegment=(tBegin-0)=tBegin
     let b = bddCase(tBegin, waitingTime, g.deltaT);
@@ -140,7 +155,7 @@ function isDetected(g: Globals, multiplier: Real, tBegin: Real) => Bool {
     if (b is DeltaT) {
         return isDetected(g, multiplier, tNew);
     }
-
+   
     // We have a speciation or extinction (b is Event)
     assume isSpeciation ~ Bernoulli(g.lambda/(g.lambda+g.mu));
 
@@ -153,10 +168,10 @@ function isDetected(g: Globals, multiplier: Real, tBegin: Real) => Bool {
 }
 
 // Simulate hidden speciation process along a branch in the reconstructed tree
-function simHiddenSpeciation(g: Globals, multiplier: Real, tBegin:Real, tEnd: Real) => Real {
+function simHiddenSpeciation(g: Globals, multiplier: Real, tBegin:Real, tEnd: Real) => Real[] {
 
     // We always need to consider the possibility of speciation
-    assume waitingTime ~ Exponential(multiplier*g.lambda);
+    let waitingTime = waitTime(multiplier, g.lambda);
 
     // Find out BDD case and time frame we will be considering
     let b = bddCase(tBegin-tEnd, waitingTime, g.deltaT);
@@ -169,24 +184,69 @@ function simHiddenSpeciation(g: Globals, multiplier: Real, tBegin:Real, tEnd: Re
     if (multiplier > 1e4) {
         // printLn(concat("Multiplier hit upper limit in simHiddenSpeciation: ",real2string(multiplier)));
         weight 0.0;
-        return multiplier;
+        return [multiplier,0.0];
     }
     let multiplier = max(multiplier,1e-6);
 
     // Test for termination case (end of branch)
     if (b is EndOfBranch) {
-        return multiplier;
+        return [multiplier, g.deltaT - b.timeSegment];
     }
-
+    
     // Compute new time point
     let tNew = tBegin - b.timeSegment;
 
     // If waitingTime is smallest, there is the hidden subtree resulting from
-    // the speciation event to consider
+    // the speciation event to consider 
     if (b is Event) {
         if (isDetected(g, multiplier, tNew)) {
             weight 0.0;
-            return multiplier;
+            return [multiplier,0.0];
+        }
+        weight 2.0; // Double the weight because of the rotational symmetry
+    }
+
+    // Continue the simulation (b is Event or b is DeltaT)
+    return simHiddenSpeciation(g, multiplier, tNew, tEnd);
+}
+
+// Simulate hidden speciation process along a branch in the reconstructed tree
+// Needed this way to assure the alignement of the first multiplier draw
+function firstSectionHiddenSpeciation(g: Globals, multiplier: Real, tBegin:Real, tEnd:Real, deltaTLeft: Real) => Real[] {
+
+    // We always need to consider the possibility of speciation
+    let waitingTime = waitTime(multiplier, g.lambda);
+
+    // Find out BDD case and time frame we will be considering
+    let b = bddCase(tBegin - tEnd, waitingTime, deltaTLeft);
+
+    // We cannot die during this time frame
+    observe 0 ~ Poisson(multiplier*g.mu*b.timeSegment);
+
+     // Let the diversification rates shift
+    assume deltaLogRate ~ Gaussian(g.logAlpha, g.sigma) drift Uniform(deltaLogRate-0.1, deltaLogRate+0.1);
+    let multiplier = exp(deltaLogRate*b.timeSegment)*multiplier;
+    if (multiplier > 1e4) {
+        // printLn(concat("Multiplier hit upper limit in simHiddenSpeciation: ",real2string(multiplier)));
+        weight 0.0;
+        return [multiplier,0.0];
+    }
+    let multiplier = max(multiplier,1e-6);
+
+    // The branch is shorter than deltaTLeft
+    if (b is EndOfBranch) {
+        return [multiplier,  g.deltaT - b.timeSegment];
+    }
+    
+    // Compute new time point
+    let tNew = tBegin - b.timeSegment;
+
+    // If waitingTime is smallest, there is the hidden subtree resulting from
+    // the speciation event to consider 
+    if (b is Event) {
+        if (isDetected(g, multiplier, tNew)) {
+            weight 0.0;
+            return [multiplier,0.0];
         }
         weight 2.0; // Double the weight because of the rotational symmetry
     }
@@ -196,18 +256,25 @@ function simHiddenSpeciation(g: Globals, multiplier: Real, tBegin:Real, tEnd: Re
 }
 
 // Simulate ("walk") along the reconstructed tree
-function walk(g: Globals, multiplier: Real, parentAge: Real, node: Tree) {
+function walk(g: Globals, multiplier: Real, parentAge: Real, node: Tree, deltaTLeft: Real) {
 
     // Simulate hidden speciation on the ancestral branch
     let nodeAge = node.age;
-    let multiplier = simHiddenSpeciation(g, multiplier, parentAge, nodeAge);
+    let mul_time = firstSectionHiddenSpeciation(g, multiplier, parentAge, nodeAge, deltaTLeft);
+    let multiplier = mul_time[1];
+    let deltaTLeft = mul_time[2];
 
     // Deal with the end of the branch
     if (node is Node) {
-        observe 0.0 ~ Exponential (multiplier*g.lambda);
+        observe 0.0 ~ Exponential(multiplier*g.lambda);
         resample;
-        walk(g, multiplier, nodeAge, node.left);
-        walk(g, multiplier, nodeAge, node.right);
+        if (node.left.age < node.right.age) {
+            walk(g, multiplier, nodeAge, node.left, deltaTLeft);
+            walk(g, multiplier, nodeAge, node.right, deltaTLeft);
+        } else {
+            walk(g, multiplier, nodeAge, node.right, deltaTLeft);
+            walk(g, multiplier, nodeAge, node.left, deltaTLeft);
+        }
     } else {
         observe true ~ Bernoulli(g.rho);
         resample;
@@ -215,8 +282,8 @@ function walk(g: Globals, multiplier: Real, parentAge: Real, node: Tree) {
 }
 
 // Model function for BDD2
-model function bdd2(tree: Tree, rho: Real, numIntervals: Int) => Real[] {
-
+model function bdd2(tree: Tree, rho: Real, numIntervals: Int) => ReturnType {
+  
     // Compute the time for one of the intervals
     let deltaT = tree.age / int2real(numIntervals);
 
@@ -227,12 +294,13 @@ model function bdd2(tree: Tree, rho: Real, numIntervals: Int) => Real[] {
     let meanLambdaPrior = 2.0 * log(expectedTotalLeaves) / tree.age;
 
     // ClaDS2-like settings (priors as in concept paper except that mean of lambda is data dependent)
-    assume lambda ~ Gamma(1.0, meanLambdaPrior)     drift Uniform(lambda/1.1,lambda*1.1);               // Multiplier probably more efficient, tuning param 1.1
-    assume epsilon ~ Uniform(0.0, 1.0)              drift Uniform(max(epsilon-0.1,0.0),min(epsilon+0.1,1.0));  // Sliding window, tuning param width=0.2
+    assume lambda ~ Gamma(1.0, meanLambdaPrior)     drift Uniform(max(lambda/1.05,1e-6),min(lambda*1.05,10.0));
+    assume epsilon ~ Uniform(0.0, 1.0)              drift Uniform(max(epsilon/1.05, 0.0),min(epsilon*1.05,1.0));
     let mu = epsilon*lambda;
-    assume sigma_x ~ Gamma(1.0, 1.0)                drift Gamma(sigma_x/1.1,sigma_x*1.1);               // Multiplier probably more efficient, tuning param 1.1
+    assume sigma_x ~ Gamma(1.0, 1.0)                drift Uniform(sigma_x/1.1, sigma_x*1.1);
     let sigma = sqrt(0.2*meanLambdaPrior/sigma_x);
-    assume logAlpha ~ Gaussian(0.0, sigma)          drift Uniform(logAlpha-0.05,logAlpha+0.05);         // Sliding window, tuning param width=0.1
+    assume logAlpha ~ Gaussian(0.0, sigma)          drift Uniform(logAlpha-0.1, logAlpha+0.1);
+
 
     // Package global model variables in one object
     let g = Globals {
@@ -244,22 +312,23 @@ model function bdd2(tree: Tree, rho: Real, numIntervals: Int) => Real[] {
         deltaT   = deltaT
     };
 
-    // printLn(concat("lambda = ",real2string(lambda)));
-    // printLn(concat("mu = ",real2string(mu)));
-    // printLn(concat("sigma = ",real2string(sigma)));
-    // printLn(concat("logAlpha = ",real2string(logAlpha)));
-
     // Correct for tip labels and rotations
     logWeight log(2.0) * (numLeaves - 1.0) - logFactorial(numLeaves);
-
+    
     // Walk over tree
-    walk(g, 1.0, tree.age, tree.left);
-    walk(g, 1.0, tree.age, tree.right);
+    walk(g, 1.0, tree.age, tree.left, deltaT);
+    walk(g, 1.0, tree.age, tree.right, deltaT);
 
     // Condition on MRCA detection
     let m = numTrialsUntilMRCADetection(g, tree.age, 1000);
     weight int2real(m);
     resample;
-
-    return [lambda, mu, logAlpha, sigma, int2real(m)];
+    
+    return ReturnType {
+        lambda = lambda,
+        mu = mu,
+        logAlpha = logAlpha,
+        sigma = sigma
+    };
 }
+

--- a/lib/models/diversification/clads2.tppl
+++ b/lib/models/diversification/clads2.tppl
@@ -1,5 +1,7 @@
 // ClaDS2 model script
 
+//import "treeppl::lib/trees.tppl"
+//import "treeppl::lib/math.tppl"
 
 // Types
 // -----
@@ -14,6 +16,12 @@ type Globals = Globals {
     rho:        Real
 }
 
+type ReturnType = ReturnType{
+    lambda:     Real, 
+    mu:         Real, 
+    logAlpha:   Real, 
+    sigma:      Real
+}
 
 // Help function
 // -------------
@@ -51,7 +59,7 @@ function numTrialsUntilMRCADetection(g: Globals, tRoot: Real, mMax: Int) => Int 
     }
 
     // MRCA is not detected, continue recursion
-    return (1 + numTrialsUntilMRCADetection(g, tRoot, mMax));
+    return (1 + numTrialsUntilMRCADetection(g, tRoot, mMax-1));
 }
 
 // Forward simulation determining whether a tree survives and is detected (sampled)
@@ -75,13 +83,13 @@ function isDetected(g: Globals, multiplier: Real, tBegin: Real) => Bool {
 
     assume deltaLogRate ~ Gaussian(g.logAlpha, g.sigma);
     let multiplier = multiplier * exp(deltaLogRate);
-    if (multiplier > 1e4) {
+    if (multiplier > 1e6) {
       return true;
     }
     let multiplier = max(multiplier,1e-6);
 
     assume waitingTime ~ Exponential(multiplier*(g.lambda+g.mu));
-    let newTime = tBegin - waitingTime;
+    let newTime = tBegin - waitingTime; 
 
     if (newTime < 0.0) {
         assume detected ~ Bernoulli(g.rho);
@@ -101,9 +109,7 @@ function isDetected(g: Globals, multiplier: Real, tBegin: Real) => Bool {
 // Simulate hidden speciation along an observed branch
 function simHiddenSpeciation(g: Globals, multiplier: Real, startTime: Real, endTime: Real) => Real {
 
-    assume deltaLogRate ~ Gaussian(g.logAlpha, g.sigma);
-    let multiplier = multiplier * exp(deltaLogRate);
-    if (multiplier > 1e4) {
+    if (multiplier > 1e6) {
       weight 0.0;
       return multiplier;
     }
@@ -120,9 +126,11 @@ function simHiddenSpeciation(g: Globals, multiplier: Real, startTime: Real, endT
         }
         observe 0 ~ Poisson(multiplier*g.mu*waitingTime);
         weight 2.0;
+        assume deltaLogRate ~ Gaussian(g.logAlpha, g.sigma);
+        let multiplier = multiplier * exp(deltaLogRate);
         return simHiddenSpeciation(g, multiplier, newTime, endTime);
     }
-
+    
     // Passed the end, we are done
     observe 0 ~ Poisson(multiplier*g.mu*(startTime-endTime));
     return multiplier;
@@ -131,24 +139,31 @@ function simHiddenSpeciation(g: Globals, multiplier: Real, startTime: Real, endT
 
 // Simulate process ("walk") along the observed tree
 function walk(g: Globals, multiplier: Real, parentAge: Real, node: Tree) {
-
+   
     let nodeAge = node.age;
+    // Align multiplier in head of the branch
+    assume deltaLogRate ~ Gaussian(g.logAlpha, g.sigma) drift Uniform(deltaLogRate-0.1, deltaLogRate+0.1);
+    let multiplier = multiplier * exp(deltaLogRate);
     let multiplier = simHiddenSpeciation(g, multiplier, parentAge, nodeAge);
 
     if (node is Node) {
-        observe 0.0 ~ Exponential(multiplier*g.lambda);
+        observe 0.0 ~ Exponential(multiplier*g.lambda) ;
         resample;
-        walk(g, multiplier, nodeAge, node.left);
-        walk(g, multiplier, nodeAge, node.right);
+        if (node.left.age < node.right.age) {
+            walk(g, multiplier, nodeAge, node.left);
+            walk(g, multiplier, nodeAge, node.right);
+        } else {
+            walk(g, multiplier, nodeAge, node.right);
+            walk(g, multiplier, nodeAge, node.left);
+        }
     } else {
         observe true ~ Bernoulli(g.rho);
         resample;
     }
 }
 
-
 // Main model function
-model function clads2(tree: Tree, rho: Real) => Real[] {
+model function clads2(tree: Tree, rho: Real) => ReturnType {
 
     // Set priors such that net diversification (lambda - mu) is likely
     // to generate a tree of the observed size.
@@ -156,12 +171,13 @@ model function clads2(tree: Tree, rho: Real) => Real[] {
     let expectedTotalLeaves = numLeaves / rho;
     let meanLambdaPrior = 2.0 * log(expectedTotalLeaves) / tree.age;
 
-    assume lambda ~ Gamma(1.0, meanLambdaPrior)     drift Uniform(max(lambda/1.1,1e-6),min(lambda*1.1,1e6));
-    assume epsilon ~ Uniform(0.0,1.0)               drift Uniform(max(epsilon-0.1,0.0),min(epsilon+0.1,1.0));
+    // ClaDS2-like settings (priors as in concept paper except that mean of lambda is data dependent)
+    assume lambda ~ Gamma(1.0, meanLambdaPrior)     drift Uniform(max(lambda/1.1,1e-6),min(lambda*1.1,10.0));
+    assume epsilon ~ Uniform(0.0, 1.0)              drift Uniform(max(epsilon/1.2, 0.0),min(epsilon*1.2,1.0));
     let mu = epsilon*lambda;
-    assume sigma ~ Gamma(1.0, 1.0)                  drift Gamma(sigma/1.1, 1.1*sigma);
-    let sigma = sqrt(0.2 / sigma);
-    assume logAlpha ~ Gaussian(0.0, sigma)          drift Uniform(logAlpha-0.05,logAlpha+0.05);
+    assume sigma_x ~ Gamma(1.0, 1.0)                drift Uniform(sigma_x/1.1, sigma_x*1.1);
+    let sigma = sqrt(0.2*meanLambdaPrior/sigma_x);
+    assume logAlpha ~ Gaussian(0.0, sigma)          drift Uniform(logAlpha-0.1, logAlpha+0.1); // Sliding window, tuning param width=0.1
 
     let g = Globals {
         lambda      = lambda,
@@ -184,5 +200,11 @@ model function clads2(tree: Tree, rho: Real) => Real[] {
     weight int2real(m);
     resample;
 
-    return [lambda, mu, logAlpha, sigma, int2real(m)];
+    return ReturnType {
+        lambda = lambda,
+        mu = mu,
+        logAlpha = logAlpha,
+        sigma = sigma
+    };
 }
+

--- a/models/diversification/data/testdata_bdd.json
+++ b/models/diversification/data/testdata_bdd.json
@@ -1,0 +1,268 @@
+{ "tree":
+  { "__constructor__": "Node", "__data__": {
+   "left":
+    { "__constructor__": "Node", "__data__": {
+     "left":
+      { "__constructor__": "Node", "__data__": {
+       "left":
+        { "__constructor__": "Node", "__data__": {
+         "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+        , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+        , "age": 5.635787971}
+        }
+      , "right":
+        { "__constructor__": "Node", "__data__": {
+         "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+        , "right":
+          { "__constructor__": "Node", "__data__": {
+           "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+          , "right":
+            { "__constructor__": "Node", "__data__": {
+             "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+            , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+            , "age": 4.788021775}
+            }
+          , "age": 7.595901077}
+          }
+        , "age": 9.436625313}
+        }
+      , "age": 12.344087935000001}
+      }
+    , "right":
+      { "__constructor__": "Node", "__data__": {
+       "left":
+        { "__constructor__": "Node", "__data__": {
+         "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+        , "right":
+          { "__constructor__": "Node", "__data__": {
+           "left":
+            { "__constructor__": "Node", "__data__": {
+             "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+            , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+            , "age": 3.934203877}
+            }
+          , "right":
+            { "__constructor__": "Node", "__data__": {
+             "left":
+              { "__constructor__": "Node", "__data__": {
+               "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "age": 3.151799953}
+              }
+            , "right":
+              { "__constructor__": "Node", "__data__": {
+               "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "age": 5.054547857}
+              }
+            , "age": 6.284896356999999}
+            }
+          , "age": 7.815689970999999}
+          }
+        , "age": 10.32243059}
+        }
+      , "right":
+        { "__constructor__": "Node", "__data__": {
+         "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+        , "right":
+          { "__constructor__": "Node", "__data__": {
+           "left":
+            { "__constructor__": "Node", "__data__": {
+             "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+            , "right":
+              { "__constructor__": "Node", "__data__": {
+               "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "age": 1.519406055}
+              }
+            , "age": 4.987038163}
+            }
+          , "right":
+            { "__constructor__": "Node", "__data__": {
+             "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+            , "right":
+              { "__constructor__": "Node", "__data__": {
+               "left":
+                { "__constructor__": "Node", "__data__": {
+                 "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                , "age": 0.6302632958}
+                }
+              , "right":
+                { "__constructor__": "Node", "__data__": {
+                 "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                , "right":
+                  { "__constructor__": "Node", "__data__": {
+                   "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                  , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                  , "age": 1.962579854}
+                  }
+                , "age": 3.732932004}
+                }
+              , "age": 5.5933070698}
+              }
+            , "age": 6.096453021}
+            }
+          , "age": 8.265483252}
+          }
+        , "age": 10.86835485}
+        }
+      , "age": 12.551924091}
+      }
+    , "age": 13.472886809}
+    }
+  , "right":
+    { "__constructor__": "Node", "__data__": {
+     "left":
+      { "__constructor__": "Node", "__data__": {
+       "left":
+        { "__constructor__": "Node", "__data__": {
+         "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+        , "right":
+          { "__constructor__": "Node", "__data__": {
+           "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+          , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+          , "age": 4.534421013}
+          }
+        , "age": 12.46869821}
+        }
+      , "right":
+        { "__constructor__": "Node", "__data__": {
+         "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+        , "right":
+          { "__constructor__": "Node", "__data__": {
+           "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+          , "right":
+            { "__constructor__": "Node", "__data__": {
+             "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+            , "right":
+              { "__constructor__": "Node", "__data__": {
+               "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "age": 6.306427821}
+              }
+            , "age": 9.40050129}
+            }
+          , "age": 13.85876825}
+          }
+        , "age": 20.68766993}
+        }
+      , "age": 22.82622451}
+      }
+    , "right":
+      { "__constructor__": "Node", "__data__": {
+       "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+      , "right":
+        { "__constructor__": "Node", "__data__": {
+         "left":
+          { "__constructor__": "Node", "__data__": {
+           "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+          , "right":
+            { "__constructor__": "Node", "__data__": {
+             "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+            , "right":
+              { "__constructor__": "Node", "__data__": {
+               "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "right":
+                { "__constructor__": "Node", "__data__": {
+                 "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                , "age": 4.220057646}
+                }
+              , "age": 8.451051062}
+              }
+            , "age": 11.54072627}
+            }
+          , "age": 15.28839572}
+          }
+        , "right":
+          { "__constructor__": "Node", "__data__": {
+           "left":
+            { "__constructor__": "Node", "__data__": {
+             "left":
+              { "__constructor__": "Node", "__data__": {
+               "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "age": 8.614086751}
+              }
+            , "right":
+              { "__constructor__": "Node", "__data__": {
+               "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "right":
+                { "__constructor__": "Node", "__data__": {
+                 "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                , "right":
+                  { "__constructor__": "Node", "__data__": {
+                   "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                  , "right":
+                    { "__constructor__": "Node", "__data__": {
+                     "left":
+                      { "__constructor__": "Node", "__data__": {
+                       "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                      , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                      , "age": 0.9841688636}
+                      }
+                    , "right":
+                      { "__constructor__": "Node", "__data__": {
+                       "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                      , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                      , "age": 1.04896206}
+                      }
+                    , "age": 1.7140599232}
+                    }
+                  , "age": 3.786162534}
+                  }
+                , "age": 8.788450495}
+                }
+              , "age": 11.05846217}
+              }
+            , "age": 15.008504768}
+            }
+          , "right":
+            { "__constructor__": "Node", "__data__": {
+             "left":
+              { "__constructor__": "Node", "__data__": {
+               "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "age": 11.15685875}
+              }
+            , "right":
+              { "__constructor__": "Node", "__data__": {
+               "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+              , "right":
+                { "__constructor__": "Node", "__data__": {
+                 "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                , "right":
+                  { "__constructor__": "Node", "__data__": {
+                   "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                  , "right":
+                    { "__constructor__": "Node", "__data__": {
+                     "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                    , "right":
+                      { "__constructor__": "Node", "__data__": {
+                       "left": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                      , "right": {"__constructor__": "Leaf", "__data__": { "age": 0.0}}
+                      , "age": 1.900561313}
+                      }
+                    , "age": 3.100150132}
+                    }
+                  , "age": 6.043650727}
+                  }
+                , "age": 12.38252513}
+                }
+              , "age": 12.61785812}
+              }
+            , "age": 15.396725736}
+            }
+          , "age": 16.828404506}
+          }
+        , "age": 20.368109703000002}
+        }
+      , "age": 23.74299959}
+      }
+    , "age": 32.145876657}
+    }
+  , "age": 34.940139089}
+  }
+, "deltaT": 0.1
+}


### PR DESCRIPTION
In this PR I have make the following change 
 - Naming of the output values
 - Properly align models to make augmentation data algorithm effective
 - Sort the branch for exploring the long one first (better survival of smc particules)

This is just a draft because :

- Clads2 : result are coherent between previous studies, smc and mcmc for Alcedinidae and Muscicapidae.
- Bdd2 : result are incoherent between smc and mcmc for Alcedinidae and Muscicapidae.
  - smc chains give result how seems coherent with previous analyses. 
  - mcmc chains diverges for Alcedinidae and Muscicapidae.
  - reduced bdd2 to crbd converge to normConst crbd analyticals values for Alcedinidae and Muscicapidae.

---

Suggest bullets to add to [the changelog](https://treeppl.org/docs/changelog) below (under `###` headings), if any. A PR that has a user-visible change should have a bullet, even if it's, e.g., just a bugfix.

## TreePPL Release Notes

### Added

### Changed
- Properly align clads and bdd models
### Deprecated

### Removed

### Fixed

### Security
