### PR TITLE
Add --version flag

### DIFF
--- a/lib/internal/lib-compile.mc
+++ b/lib/internal/lib-compile.mc
@@ -51,4 +51,4 @@ let runInference : all res. all inferOpts. RunInferenceConfig res inferOpts -> (
       repeat runOnce sweeps in
     let options = optMap5 run
       dataFile (_inferTimeMs config.inferTimeMs) (_sweeps config.sweeps) (_seed config.seed) config.inferOpts in
-    optParseWithHelp (head argv) "" options (tail argv) ()
+    optParseWithHelp (optParserHelpDef (head argv)) options (tail argv) ()

--- a/misc/packaging/treeppl-unwrapped.nix
+++ b/misc/packaging/treeppl-unwrapped.nix
@@ -3,7 +3,7 @@
   miking-lib, miking-unwrapped, miking-dppl-lib,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: rec {
   pname = "treeppl";
   version = "0.4";
 
@@ -17,6 +17,11 @@ stdenv.mkDerivation (finalAttrs: {
     ocamlPackages.ocaml
     ocamlPackages.linenoise
   ];
+
+  preBuild = ''
+    substituteInPlace src/tpplc.mc \
+      --replace-fail "~git~" "${version}"
+  '';
 
   makeFlags = [ "bin_path=$(out)/bin" "lib_path=$(out)/lib/mcore/treeppl" ];
 

--- a/src/tpplc.mc
+++ b/src/tpplc.mc
@@ -22,6 +22,15 @@ mexpr
 
 use TreePPLThings in
 
+let _version : OptParser String = optNoArg
+  -- NOTE(vipa, 2026-08-11): The "~git~" string below will be
+  -- substituted for a proper version by the Nix derivation when
+  -- building a release.
+  { optNoArgDef "tpplc version ~git~" with long = "version"
+  , description = "Print the version number of the compiler."
+  , category = catDebug
+  } in
+
 let _cpsDefault : String = "full" in
 let _cps : OptParser String =
   let opt = optArg
@@ -590,7 +599,7 @@ let transformationOptions : OptParser TransformationOptions =
     optOr (optMap (lam str. setOfSeq cmpString (strSplit "," str)) opt) (optPure (setEmpty cmpString)) in
   optMap5 mk printModel extractSimplification staticDelay debugPhases debugDumpPhases in
 
-let options : OptParser (TpplFrontendOptions, TransformationOptions, MkInferMethod) =
+let options : OptParser (Either String (TpplFrontendOptions, TransformationOptions, MkInferMethod)) =
   let inference = foldl1 optOr
     [ isLwOptions
     , smcApfOptions
@@ -601,8 +610,25 @@ let options : OptParser (TpplFrontendOptions, TransformationOptions, MkInferMeth
     , graphMcmcOptions
     , pmcmcPimhOptions
     ] in
-  optMap3 (lam a. lam b. lam c. (a, b, c)) tpplFrontendOptions transformationOptions inference in
+  let options = optMap3 (lam a. lam b. lam c. (a, b, c))
+    tpplFrontendOptions
+    transformationOptions
+    inference in
+  let help =
+    { optParserHelpDef "tpplc" with description = "Compile a TreePPL program to a sampler using the given inference method."
+    , orderedCategories = [catMethod, catCompile, catRun, catDebug]
+    } in
+  let options = optParserWithHelp help options in
+  optOr (optMap (lam x. Left x) _version) options in
 
-match optParseWithHelp "tpplc" "" options (tail argv)
-  with (frontend, transformations, mkInferenceMethod) in
-compileTpplToExecutable frontend transformations mkInferenceMethod
+
+switch optParse options (tail argv)
+case Left err then
+  printLn err;
+  exit 1
+case Right (Left info) then
+  printLn info;
+  exit 0
+case Right (Right (frontend, transformations, mkInferenceMethod)) then
+  compileTpplToExecutable frontend transformations mkInferenceMethod
+end


### PR DESCRIPTION
This PR uses the changes in https://github.com/miking-lang/miking/pull/1006, and also adds a new `--version` flag.

Note that neither  `--version` nor `--help` are visible in the text for `--help`. This isn't ideal, but adding them in the obvious way would merge the `Usage` lines into one line with all inference methods, one line for `--help` and one line for `--version`, which seems significantly worse to me.

---

Suggest bullets to add to [the changelog](https://treeppl.org/docs/changelog) below (under `###` headings), if any. A PR that has a user-visible change should have a bullet, even if it's, e.g., just a bugfix.

## TreePPL Release Notes

### Added
- A `tpplc --version` flag that prints a version number when given to a released compiler and `~git~` when given to a manually built compiler.  

### Changed

### Deprecated

### Removed

### Fixed

### Security
