### PR TITLE
Better error message on lexing error

### DIFF
--- a/src/treeppl.syn
+++ b/src/treeppl.syn
@@ -57,6 +57,8 @@ token {fragment = TpplLineCommentParser,}
 token {fragment = TpplMultilineCommentParser,}
 token {fragment = WhitespaceParser,}
 
+token {fragment = ErrorTokenParser,}
+
 type FileTppl
 type DeclTppl
 type TypeTppl


### PR DESCRIPTION
This PR makes lexing errors point to the appropriate point in the source, not just call `never`. For example, accidentally using `#` for comments:

<img width="666" height="54" alt="image" src="https://github.com/user-attachments/assets/b51d4e56-78f0-4674-b56b-3e020cd19784" />

---

Suggest bullets to add to [the changelog](https://treeppl.org/docs/changelog) below (under `###` headings), if any. A PR that has a user-visible change should have a bullet, even if it's, e.g., just a bugfix.

## TreePPL Release Notes

### Added

### Changed

### Deprecated

### Removed

### Fixed
- Lexing errors now point at the actual problem

### Security
