### PR TITLE
Make the pigeons test less precise

### DIFF
--- a/misc/pigeons/test_responses.sh
+++ b/misc/pigeons/test_responses.sh
@@ -47,7 +47,7 @@ awk '
 
     d = vals[1] - vals[0]
     for (i = 2; i < n; i++) {
-      if (abs(vals[i] - vals[i-1] - d) > 1e-5) {
+      if (abs(vals[i] - vals[i-1] - d) > 1e-3) {
         printf "FAIL: not an arithmetic progression: "
         for (i = 0; i < n; i++) printf "%s ", vals[i]
         print ""


### PR DESCRIPTION
We're running into some flaky tests because of some randomness + floating point instability (I assume anyway), where the pigeons tests (which look for an arithmetic progression) are more precise than the system actually supports. It checks that the difference between adjacent numbers differ by < 1e-5, but I've seen differences at 1e-4 (for fairly large numbers), so this seems overly ambitious.

---

Suggest bullets to add to [the changelog](https://treeppl.org/docs/changelog) below (under `###` headings), if any. A PR that has a user-visible change should have a bullet, even if it's, e.g., just a bugfix.

## TreePPL Release Notes

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security
