### PR TITLE
Record that we're using a gawk extension

### DIFF
--- a/misc/pigeons/test_responses.sh
+++ b/misc/pigeons/test_responses.sh
@@ -13,7 +13,10 @@ $tppl_exe "$data_file" | tee "$response_file"
 
 # Extract only numeric response values; a blank response() becomes an
 # empty line
-awk '
+#
+# NOTE: uses gawk's 3-argument match() to capture the numeric group, which
+# is not supported by other awk implementations (e.g. mawk, BSD awk).
+gawk '
   /^response\(/ {
     if ($0 == "response()") {
       print ""
@@ -23,7 +26,7 @@ awk '
     }
   }
 ' "$response_file" |
-awk '
+gawk '
   # Process blocks separated by empty lines
   NF == 0 {
     check_block()


### PR DESCRIPTION
Turns out the test script for Pigeons uses a GNU-specific extension to `awk`, this PR records that in the test script.

---

Suggest bullets to add to [the changelog](https://treeppl.org/docs/changelog) below (under `###` headings), if any. A PR that has a user-visible change should have a bullet, even if it's, e.g., just a bugfix.

## TreePPL Release Notes

### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security
