### PR TITLE
Add `all` function

### DIFF
--- a/lib/auto-import/sequence.mc
+++ b/lib/auto-import/sequence.mc
@@ -12,3 +12,4 @@ let seqSubsequence = subsequence
 let seqFoldl = foldl
 let seqFoldli = foldli
 let seqAny = any
+let seqAll = lam p. lam s. not (any (compose not p) s)

--- a/lib/auto-import/sequence.tppl
+++ b/lib/auto-import/sequence.tppl
@@ -74,6 +74,10 @@ function any[X](f : Function(X) => Bool, l : X[]) => Bool {
   return seqAny(f)(l);
 }
 
+function all[X](f : Function(X) => Bool, l : X[]) => Bool {
+  return seqAll(f)(l);
+}
+
 function qSort[X](cmp : Function(X, X)=>Int, l : X[]) => X[] {
   return quickSort(function(a : X) => Function(X) => Int {return function(b : X) => Int {return cmp(a, b);};})(l);
 }


### PR DESCRIPTION
We have an `any`, but not an `all` function which I find inconsistent, so this PR adds one.

---

Suggest bullets to add to [the changelog](https://treeppl.org/docs/changelog) below (under `###` headings), if any. A PR that has a user-visible change should have a bullet, even if it's, e.g., just a bugfix.

## TreePPL Release Notes

### Added

- Add `all` function.

### Changed

### Deprecated

### Removed

### Fixed

### Security
